### PR TITLE
Feature/before after

### DIFF
--- a/src/core/commands/Destroy.js
+++ b/src/core/commands/Destroy.js
@@ -103,13 +103,20 @@ class Command {
 					// Check, if current view is in given root element...
 					if ($.contains(root, view.el)) {
 
-						// Call destroy method on view...
-						if (typeof view.destroy === 'function') {
-							view.destroy();
+						if (this.beforeEach(view)) {
+							// Call destroy method on view...
+							if (typeof view.destroy === 'function') {
+								view.destroy();
+							}
+
+							// Remove view from wired views...
+							views.splice(index, 1);
+
+							this.afterEach(view);
+						} else {
+							index++;
 						}
 
-						// Remove view from wired views...
-						views.splice(index, 1);
 					} else {
 						index++;
 					}
@@ -125,6 +132,36 @@ class Command {
 		}
 
 		this.postExecute();
+	}
+
+	/**
+	 * Overwrite this function to add functionality before each view will be
+	 * destroyed. If you like to cleanup data or references depending on each
+	 * view, you can overwrite this function to do this.
+	 *
+	 * You can use this function to stop further actions for this view by
+	 * returning "false". By default, this function returns "true".
+	 *
+	 * @param view {Backbone.View} is the view instance before .destroy() will
+	 * be called on it.
+	 * @return {Boolean} indicates if the view should be destroyed. Default value
+	 * is "true" which means the view will be destroyed.
+	 */
+	beforeEach(/* view*/) {
+		// Overwrite this...
+		return true;
+	}
+
+	/**
+	 * Overwrite this function to add functionality after each view has been
+	 * destroyed. If you like to cleanup data or references depending on each
+	 * view, you can overwrite this function to do this.
+	 *
+	 * @param view {Backbone.View} is the view instance after .destroy() was
+	 * be called on it.
+	 */
+	afterEach(/* view, */) {
+		// Overwrite this...
 	}
 
 	/**

--- a/src/core/commands/Initialize.js
+++ b/src/core/commands/Initialize.js
@@ -125,18 +125,66 @@ class Command {
 			views = context.getObject(settings.namespace);
 		}
 
-		$(settings.selector, data.root).each(function() {
+		$(settings.selector, data.root).each(function(index) {
 			if (_.where(views, {el: this}).length === 0) {
-				views.push(new settings.viewclass($.extend({
-					el: this,
-					context: context
-				}, settings.viewoptions)).render());
+				var
+					options = $.extend({el: this, context: context}, settings.viewoptions),
+					view
+				;
+
+				if (!self.beforeEach(options, this, index)) {
+					return;
+				}
+
+				view = new settings.viewclass(options).render();
+
+				if (!self.afterEach(view, this, index)) {
+					return;
+				}
+
+				views.push(view);
 			}
 		});
 
 		context.wireValue(settings.namespace, views);
 
 		this.postExecute();
+	}
+
+	/**
+	 * Overwrite this function to add functionality before each view will be
+	 * created. If you like to modify options for each view depending on element
+	 * or index, you can overwrite this function to do this.
+	 *
+	 * @param options {Object} are the current options which will be passed
+	 * into the upcoming created view.
+	 * @param element {Element} is the DOM-element on which the view will be
+	 * rendered.
+	 * @param index {Number} is the current index of all matched DOM-elements.
+	 * @return {Boolean} indicates if the view should be created. Default value
+	 * is "true" which means the view will be created and rendered.
+	 */
+	beforeEach(/* options, element, index */) {
+		// Overwrite this...
+		return true;
+	}
+
+	/**
+	 * Overwrite this function to add functionality after each view was
+	 * created. If you like to call functions or set properties for each new
+	 * view depending on element or index, you can overwrite this function to
+	 * do this.
+	 *
+	 * @param view {Backbone.View} is the newly create view.
+	 * @param element {Element} is the DOM-element on which the view was created.
+	 * @param index {Number} is the current index of all matched DOM-elements.
+	 * @return {Boolean} indicates if the view should added into the list of
+	 * created views stored in the given namespace "settings.namespace". Default
+	 * value is "true" which means it will be added.
+	 */
+	afterEach(/* view, element, index */) {
+		// Overwrite this...
+		return true;
 	}
 
 	/**

--- a/src/core/commands/Initialize.js
+++ b/src/core/commands/Initialize.js
@@ -156,6 +156,9 @@ class Command {
 	 * created. If you like to modify options for each view depending on element
 	 * or index, you can overwrite this function to do this.
 	 *
+	 * You can use this function to stop further actions for this element by
+	 * returning "false". By default, this function returns "true".
+	 *
 	 * @param options {Object} are the current options which will be passed
 	 * into the upcoming created view.
 	 * @param element {Element} is the DOM-element on which the view will be
@@ -174,6 +177,9 @@ class Command {
 	 * created. If you like to call functions or set properties for each new
 	 * view depending on element or index, you can overwrite this function to
 	 * do this.
+	 *
+	 * You can use this function to stop further actions for this view by
+	 * returning "false". By default, this function returns "true".
 	 *
 	 * @param view {Backbone.View} is the newly create view.
 	 * @param element {Element} is the DOM-element on which the view was created.

--- a/tests/core/commands/destroy.js
+++ b/tests/core/commands/destroy.js
@@ -187,6 +187,86 @@ QUnit.test(
 );
 
 QUnit.test(
+	'should call beforeEach() on instance for each view',
+	function(assert) {
+		var
+			instance = create(
+				{namespace: 'test:views'},
+				this.context
+			),
+			views = this.views.concat()
+		;
+
+		instance.beforeEach = sinon.spy(function() {return true;});
+		instance.execute();
+
+		assert.equal(instance.beforeEach.callCount, 3);
+		assert.equal(instance.beforeEach.getCall(0).args[0], views[0]);
+		assert.equal(instance.beforeEach.getCall(1).args[0], views[1]);
+		assert.equal(instance.beforeEach.getCall(2).args[0], views[2]);
+	}
+);
+
+// QUnit.test(
+// 	'should not destroy views when beforeEach() returns "false"',
+// 	function(assert) {
+// 		var
+// 			callbacks = [],
+// 			instance = create(
+// 				{namespace: 'test:views'},
+// 				this.context
+// 			)
+// 		;
+
+// 		_.each(this.views, function(view) {
+// 			var callback = sinon.spy();
+// 			view.destroy = callback;
+// 			callbacks.push(callback);
+// 		}, this);
+
+// 		instance.beforeEach = sinon.spy(function() {return false;});
+// 		instance.execute();
+
+// 		assert.equal(instance.beforeEach.callCount, 3);
+// 		assert.ok(callbacks[0].notCalled);
+// 		assert.ok(callbacks[1].notCalled);
+// 		assert.ok(callbacks[2].notCalled);
+// 		assert.equal(this.context.getObject('test:views').length, 3);
+// 	}
+// );
+
+// QUnit.test(
+// 	'should call afterEach() on instance for each view',
+// 	function(assert) {
+// 		var
+// 			callbacks = [],
+// 			instance = create(
+// 				{namespace: 'test:views'},
+// 				this.context
+// 			),
+// 			views = this.views.concat()
+// 		;
+
+// 		_.each(this.views, function(view) {
+// 			var callback = sinon.spy();
+// 			view.destroy = callback;
+// 			callbacks.push(callback);
+// 		}, this);
+
+// 		instance.afterEach = sinon.spy();
+// 		instance.execute();
+
+// 		assert.equal(instance.afterEach.callCount, 3);
+// 		assert.equal(instance.afterEach.getCall(0).args[0], views[0]);
+// 		assert.ok(views[0].destroy.calledOnce);
+// 		assert.equal(instance.afterEach.getCall(1).args[0], views[1]);
+// 		assert.ok(views[1].destroy.calledOnce);
+// 		assert.equal(instance.afterEach.getCall(2).args[0], views[2]);
+// 		assert.ok(views[2].destroy.calledOnce);
+// 	}
+// );
+
+QUnit.test(
 	'should call preExecute() on instance',
 	function(assert) {
 		var

--- a/tests/core/commands/destroy.js
+++ b/tests/core/commands/destroy.js
@@ -207,64 +207,64 @@ QUnit.test(
 	}
 );
 
-// QUnit.test(
-// 	'should not destroy views when beforeEach() returns "false"',
-// 	function(assert) {
-// 		var
-// 			callbacks = [],
-// 			instance = create(
-// 				{namespace: 'test:views'},
-// 				this.context
-// 			)
-// 		;
+QUnit.test(
+	'should not destroy views when beforeEach() returns "false"',
+	function(assert) {
+		var
+			callbacks = [],
+			instance = create(
+				{namespace: 'test:views'},
+				this.context
+			)
+		;
 
-// 		_.each(this.views, function(view) {
-// 			var callback = sinon.spy();
-// 			view.destroy = callback;
-// 			callbacks.push(callback);
-// 		}, this);
+		_.each(this.views, function(view) {
+			var callback = sinon.spy();
+			view.destroy = callback;
+			callbacks.push(callback);
+		}, this);
 
-// 		instance.beforeEach = sinon.spy(function() {return false;});
-// 		instance.execute();
+		instance.beforeEach = sinon.spy(function() {return false;});
+		instance.execute();
 
-// 		assert.equal(instance.beforeEach.callCount, 3);
-// 		assert.ok(callbacks[0].notCalled);
-// 		assert.ok(callbacks[1].notCalled);
-// 		assert.ok(callbacks[2].notCalled);
-// 		assert.equal(this.context.getObject('test:views').length, 3);
-// 	}
-// );
+		assert.equal(instance.beforeEach.callCount, 3);
+		assert.ok(callbacks[0].notCalled);
+		assert.ok(callbacks[1].notCalled);
+		assert.ok(callbacks[2].notCalled);
+		assert.equal(this.context.getObject('test:views').length, 3);
+	}
+);
 
-// QUnit.test(
-// 	'should call afterEach() on instance for each view',
-// 	function(assert) {
-// 		var
-// 			callbacks = [],
-// 			instance = create(
-// 				{namespace: 'test:views'},
-// 				this.context
-// 			),
-// 			views = this.views.concat()
-// 		;
+QUnit.test(
+	'should call afterEach() on instance for each view',
+	function(assert) {
+		var
+			callbacks = [],
+			instance = create(
+				{namespace: 'test:views'},
+				this.context
+			),
+			views = this.views.concat()
+		;
 
-// 		_.each(this.views, function(view) {
-// 			var callback = sinon.spy();
-// 			view.destroy = callback;
-// 			callbacks.push(callback);
-// 		}, this);
+		_.each(this.views, function(view) {
+			var callback = sinon.spy();
+			view.destroy = callback;
+			callbacks.push(callback);
+		}, this);
 
-// 		instance.afterEach = sinon.spy();
-// 		instance.execute();
+		instance.afterEach = sinon.spy();
+		instance.execute();
 
-// 		assert.equal(instance.afterEach.callCount, 3);
-// 		assert.equal(instance.afterEach.getCall(0).args[0], views[0]);
-// 		assert.ok(views[0].destroy.calledOnce);
-// 		assert.equal(instance.afterEach.getCall(1).args[0], views[1]);
-// 		assert.ok(views[1].destroy.calledOnce);
-// 		assert.equal(instance.afterEach.getCall(2).args[0], views[2]);
-// 		assert.ok(views[2].destroy.calledOnce);
-// 	}
-// );
+		assert.equal(instance.afterEach.callCount, 3);
+		assert.equal(instance.afterEach.getCall(0).args[0], views[0]);
+		assert.ok(views[0].destroy.calledOnce);
+		assert.equal(instance.afterEach.getCall(1).args[0], views[1]);
+		assert.ok(views[1].destroy.calledOnce);
+		assert.equal(instance.afterEach.getCall(2).args[0], views[2]);
+		assert.ok(views[2].destroy.calledOnce);
+	}
+);
 
 QUnit.test(
 	'should call preExecute() on instance',


### PR DESCRIPTION
The initialize and destroy command now have two new functions `beforeEach` and `afterEach`. Those functions will be called for each element/view to modify settings for the view or application state.

Please check if you agree with the order and the amount of the passed params for those functions.

This PR contains:
- beforeEach, afterEach functions for the core initialize command
- beforeEach, afterEach functions for the core destroy command
- tests
