### PR TITLE
Tabs module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1570,6 +1570,15 @@ Gets and sets the selected index of tabs.
 
 
 
+#### `.isToggleable`
+
+Returns if the toggleable option is set or not.
+
+
+
+
+
+
 #### `.isMultiselectable`
 
 Retuns if the tabs module is multiselectable.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Collection of tiny backbone.geppetto modules and tools to make our live easier.
 	* [Overlay](#overlay)
 	* [Singlepage](#singlepage)
 	* [Tabfocus](#tabfocus)
+	* [Tabs](#tabs)
 	* [Tracking-Bounce](#tracking-bounce)
 	* [Tracking-Outbound](#tracking-outbound)
 	* [Tracking-Registry](#tracking-registry)
@@ -1459,6 +1460,294 @@ classname by using the 'tabfocus:settings' key on the geppetto context
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+### Tabs
+
+A module to create an accessible tab navigation based on minimal and fallback
+compatible markup. An instance of the tabs module allows the user to navigate
+via arrow keys, home and end key as well using enter or space key to toggle
+each panels visibility. By default there are only three classes to set into
+your stylesheets to enable the visual changes:
+
+* `.is-collapsed` hides closed tab panels
+* `.is-selected` marks the selected tab button
+* `.is-disabled` use this class to visually disable a tab
+
+Tabs and accordions have quite the same functionality. They only differ in
+the layout of their markup. Take a look at the second example how to enable
+an accordion behaviour.
+
+`import View from 'picnic/tabs/views/Tabs'`
+
+
+
+**Example:**
+
+```js
+		<!-- Usage as tabs module -->
+		<ul class="tabs">
+			<li><a href="#tab1" title="Open tab 1">Tab 1</a></li>
+			<li><a href="#tab2" title="Open tab 2">Tab 2</a></li>
+			<li class="is-disabled"><a href="#tab3" title="Open tab 3">Tab 3 (disabled)</a></li>
+		</ul>
+
+		<div id="#tab1"><h2>Tab 1 content</h2></div>
+		<div id="#tab2"><h2>Tab 2 content</h2></div>
+		<div id="#tab3"><h2>Tab 3 content</h2></div>
+
+		// Javascript:
+		import Tabs from 'picnic/tabs/views/Tabs';
+
+		var tabs = new Tabs({
+			el: $('.tabs')[0],
+			context: app.context
+		}).render();
+```
+
+**Example:**
+
+```js
+		<!-- Usage as accordion module -->
+		<div class="accordion">
+			<h2><a href="#section1" title="Open section 1">Section 1</a></h2>
+			<div id="section1"><p>Section 1</p></div>
+			<h2><a href="#section2" title="Open section 2">Section 2</a></h2>
+			<div id="section2"><p>Section 2</p></div>
+			<h2><a href="#section3" title="Open section 3">Section 3</a></h2>
+			<div id="section3"><p>Section 3</p></div>
+		</div>
+
+		// Javascript:
+		import Tabs from 'picnic/tabs/views/Tabs';
+
+		var accordion = new Tabs({
+			el: $('.accordion')[0],
+			context: app.context,
+			toggleable: true
+		}).render();
+```
+
+
+
+#### Constructor `View`
+Creates an instance of the view.
+
+
+|name|type|description|
+|---|---|---|
+|`options`|`object`|The settings for the view|
+|`options.context`|`object`|The reference to the backbone.geppetto context|
+|`options.el`|`object`|The element reference for a backbone.view|
+|`options.root`|`element, $element`|A reference for the view to look up for tab panels. By default this is undefined which means the lookup will be the whole DOM.|
+|`options.selectorButton`|`string`|is the selector for tab buttons|
+|`options.selected`|`number`|is the initial selected tab index. Default is 1|
+|`options.toggleable`|`boolean`|defines if a tabs state is toggleable between selected and not. This is mostly required for accordion behaviours. Default is false|
+|`options.multiselectable`|`boolean`|allows the activation of more than one tabs. Default is false|
+|`options.classSelected`|`string`|the classname to use for selected tab buttons. Default value is &#x27;is-selected&#x27;|
+|`options.classCollapsed`|`string`|the classname to use for collapsed tab panels. Default value is &#x27;is-collapsed&#x27;|
+|`options.classDisabled`|`string`|the classname to use for disabled tab elements. Default value is &#x27;is-disabled&#x27;|
+
+
+
+
+
+#### `.selected`
+
+Gets and sets the selected index of tabs.
+
+
+
+
+
+
+#### `.isMultiselectable`
+
+Retuns if the tabs module is multiselectable.
+
+
+
+
+
+
+
+
+
+#### `.render()`
+
+This renders the content of this view and enables all features.
+
+
+
+
+This function returns:
+
+|type|description|
+|---|---|
+|`object`|The instance of this view|
+
+
+
+
+
+#### `.destroy()`
+
+Removes all inner references and eventlisteners.
+
+
+
+
+
+
+
+
+#### `.getTabAt(index)`
+
+Returns the jQuery reference of a tab element at a given index.
+
+
+|name|type|description|
+|---|---|---|
+|`index`|`number`|is the index of the returned tab element.|
+
+
+
+This function returns:
+
+|type|description|
+|---|---|
+|`$element`|is the elements jQuery reference.|
+
+
+
+
+
+#### `.getButtonAt(index)`
+
+Returns the jQuery reference of a button element inside a tab at a given index.
+
+
+|name|type|description|
+|---|---|---|
+|`index`|`number`|is the index of the returned button element.|
+
+
+
+This function returns:
+
+|type|description|
+|---|---|
+|`$element`|is the elements jQuery reference.|
+
+
+
+
+
+#### `.enableTabAt(index)`
+
+Enables a tab at the given index.
+
+
+|name|type|description|
+|---|---|---|
+|`index`|`number`|is the index of the tab to be enabled|
+
+
+
+
+
+
+
+#### `.disableTabAt(index)`
+
+Disables a tab at the given index. The tab and it's tab panels content will not be accessible until its enabled again.
+
+
+|name|type|description|
+|---|---|---|
+|`index`|`number`|is the index of the tab to be disabled.|
+
+
+
+
+
+
+
+#### `.isDisabledTabAt(index)`
+
+Returns if a tab is disabled at a given index.
+
+
+|name|type|description|
+|---|---|---|
+|`index`|`number`|is the index of the tab to check|
+
+
+
+This function returns:
+
+|type|description|
+|---|---|
+|`boolean`|describes if the tab is disabled or not|
+
+
+
+
+
+#### `.isSelected(index)`
+
+Returns if the tab at the given index is selected (not collapsed).
+
+
+|name|type|description|
+|---|---|---|
+|`index`|`number`|is the index of the tab to check|
+
+
+
+This function returns:
+
+|type|description|
+|---|---|
+|`boolean`|describes if the tab is selected (not collapsed)|
+
+
+
+
+
+#### `.toggle(index, isSelected)`
+
+This toggles the selected state of a tab at a given index.
+
+
+|name|type|description|
+|---|---|---|
+|`index`|`number`|is the index of the tab|
+|`isSelected`|`boolean`|describes if the tab should be selected|
+
+
+
+
+
+
+
+#### `.toggleAll(isSelected)`
+
+This toggles selected states of all existing tabs.
+
+
+|name|type|description|
+|---|---|---|
+|`isSelected`|`boolean`|describes if the tab schould be selected|
 
 
 

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -1,0 +1,2 @@
+import Tabs from 'picnic/tabs/views/Tabs';
+export default Tabs;

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -535,7 +535,7 @@ class View extends BaseView {
 			case KEY_ARROW_LEFT:
 			case KEY_ARROW_UP:
 				event.preventDefault();
-				this._focusButtonAt(index - 1 , -1);
+				this._focusButtonAt(index - 1, -1);
 
 				break;
 			case KEY_ARROW_RIGHT:

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -30,7 +30,7 @@ var
 	KEY_END = 35,
 	KEY_HOME = 36,
 	DEFAULTS = {
-		root: undefined,
+		root: null,
 		selected: [0],
 		toggleable: false,
 		multiselectable: false,
@@ -105,7 +105,7 @@ class View extends BaseView {
 	 * @param {object} options The settings for the view
 	 * @param {object} options.context The reference to the backbone.geppetto context
 	 * @param {object} options.el The element reference for a backbone.view
-	 * @param {element|$element} options.root A reference for the view to look up for tab panels. By default this is undefined which means the lookup will be the whole DOM.
+	 * @param {element|$element} options.root A reference for the view to look up for tab panels. By default this is null which means the lookup will be the whole DOM.
 	 * @param {string} options.selectorButton is the selector for tab buttons
 	 * @param {number} options.selected is the initial selected tab index. Default is [0]. When initialize with no selection, use an empty array: [].
 	 * @param {boolean} options.toggleable defines if a tabs state is toggleable between selected and not. This is mostly required for accordion behaviours. Default is false

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -40,9 +40,80 @@ var
 	}
 ;
 
-
+/**
+ * A module to create an accessible tab navigation based on minimal and fallback
+ * compatible markup. An instance of the tabs module allows the user to navigate
+ * via arrow keys, home and end key as well using enter or space key to toggle
+ * each panels visibility. By default there are only three classes to set into
+ * your stylesheets to enable the visual changes:
+ *
+ * * `.is-collapsed` hides closed tab panels
+ * * `.is-active` marks the active tab button
+ * * `.is-disabled` use this class to visually disable a tab
+ *
+ * Tabs and accordions have quite the same functionality. They only differ in
+ * the layout of their markup. Take a look at the second example how to enable
+ * an accordion behaviour.
+ *
+ * @class Tabs
+ * @example
+ * 		<!-- Usage as tabs module -->
+ * 		<ul class="tabs">
+ *			<li><a href="#tab1" title="Open tab 1">Tab 1</a></li>
+ *			<li><a href="#tab2" title="Open tab 2">Tab 2</a></li>
+ *			<li class="is-disabled"><a href="#tab3" title="Open tab 3">Tab 3 (disabled)</a></li>
+ * 		</ul>
+ *
+ * 		<div id="#tab1"><h2>Tab 1 content</h2></div>
+ * 		<div id="#tab2"><h2>Tab 2 content</h2></div>
+ * 		<div id="#tab3"><h2>Tab 3 content</h2></div>
+ *
+ *		// Javascript:
+ *		import Tabs from 'picnic/tabs/views/Tabs';
+ *
+ *		var tabs = new Tabs({
+ *			el: $('.tabs')[0],
+ *			context: app.context
+ *		}).render();
+ *
+ * @example
+ * 		<!-- Usage as accordion module -->
+ * 		<div class="accordion">
+ * 			<h2><a href="#section1" title="Open section 1">Section 1</a></h2>
+ * 			<div id="section1"><p>Section 1</p></div>
+ *			<h2><a href="#section2" title="Open section 2">Section 2</a></h2>
+ * 			<div id="section2"><p>Section 2</p></div>
+ *			<h2><a href="#section3" title="Open section 3">Section 3</a></h2>
+ * 			<div id="section3"><p>Section 3</p></div>
+ * 		</div>
+ *
+ *		// Javascript:
+ *		import Tabs from 'picnic/tabs/views/Tabs';
+ *
+ *		var accordion = new Tabs({
+ *			el: $('.accordion')[0],
+ *			context: app.context,
+ *			toggleable: true
+ *		}).render();
+ */
 class View extends BaseView {
 
+	/**
+	 * Creates an instance of the view.
+	 *
+	 * @constructor
+	 * @param {object} options The settings for the view
+	 * @param {object} options.context The reference to the backbone.geppetto context
+	 * @param {object} options.el The element reference for a backbone.view
+	 * @param {element|$element} options.root A reference for the view to look up for tab panels. By default this is undefined which means the lookup will be the whole DOM.
+	 * @param {string} options.selectorButton is the selector for tab buttons
+	 * @param {number} options.number is the initial active tab index. Default is 1
+	 * @param {boolean} options.toggleable defines if a tabs state is toggleable between active and inactive. This is mostly required for accordion behaviours. Default is false
+	 * @param {boolean} options.multiselectable allows the activation of more than one tabs. Default is false
+	 * @param {string} options.classActive the classname to use for active tab buttons. Default value is 'is-active'
+	 * @param {string} options.classCollapsed the classname to use for collapsed tab panels. Default value is 'is-collapsed'
+	 * @param {string} options.classDisabled the classname to use for disabled tab elements. Default value is 'is-disabled'
+	 */
 	constructor(options) {
 		super($.extend({}, DEFAULTS, options));
 
@@ -58,6 +129,11 @@ class View extends BaseView {
 		);
 	}
 
+	/**
+	 * Gets and sets the active index of tabs.
+	 *
+	 * @return {number} index of tab
+	 */
 	get active() {
 		return this._active;
 	}
@@ -83,6 +159,11 @@ class View extends BaseView {
 		}
 	}
 
+	/**
+	 * Retuns if the tabs module is multiselectable.
+	 *
+	 * @return {boolean} defines the multiselectable state
+	 */
 	get isMultiselectable() {
 		// This caches the return value of the initial call:
 		this._isMultiselectable = this._isMultiselectable || (function() {
@@ -93,6 +174,11 @@ class View extends BaseView {
 		return this._isMultiselectable;
 	}
 
+	/**
+	 * This renders the content of this view and enables all features.
+	 *
+	 * @return {object} The instance of this view
+	 */
 	render() {
 		this._buttons = $();
 		this._ignoredButtons = $();
@@ -138,6 +224,9 @@ class View extends BaseView {
 		return this;
 	}
 
+	/**
+	 * Removes all inner references and eventlisteners.
+	 */
 	destroy() {
 		if (this._buttons) {
 			this._buttons
@@ -159,22 +248,52 @@ class View extends BaseView {
 		super.destroy();
 	}
 
+	/**
+	 * Returns the jQuery reference of a tab element at a given index.
+	 *
+	 * @param {number} index is the index of the returned tab element.
+	 * @return {$element} is the elements jQuery reference.
+	 */
 	getTabAt(index) {
 		return this._buttons.eq(index).parent();
 	}
 
+	/**
+	 * Returns the jQuery reference of a button element inside a tab at a
+	 * given index.
+	 *
+	 * @param {number} index is the index of the returned button element.
+	 * @return {$element} is the elements jQuery reference.
+	 */
 	getButtonAt(index) {
 		return this._buttons.eq(index);
 	}
 
+	/**
+	 * Enables a tab at the given index.
+	 *
+	 * @param {number} index is the index of the tab to be enabled
+	 */
 	enableTabAt(index) {
 		this._disableTabAt(index, false);
 	}
 
+	/**
+	 * Disables a tab at the given index. The tab and it's tab panels content
+	 * will not be accessible until its enabled again.
+	 *
+	 * @param {number} index is the index of the tab to be disabled.
+	 */
 	disableTabAt(index) {
 		this._disableTabAt(index, true);
 	}
 
+	/**
+	 * Returns if a tab is disabled at a given index.
+	 *
+	 * @param {number} index is the index of the tab to check
+	 * @return {boolean} describes if the tab is disabled or not
+	 */
 	isDisabledTabAt(index) {
 		if (index < 0 || index >= this._buttons.length) {
 			return false;
@@ -184,6 +303,12 @@ class View extends BaseView {
 			.hasClass(this.options.classDisabled);
 	}
 
+	/**
+	 * Returns if the tab at the given index is active (not collapsed).
+	 *
+	 * @param {number} index is the index of the tab to check
+	 * @return {boolean} describes if the tab is active (not collapsed)
+	 */
 	isActiveTabAt(index) {
 		if (index < 0 || index >= this._buttons.length) {
 			return false;
@@ -193,6 +318,12 @@ class View extends BaseView {
 			.hasClass(this.options.classActive);
 	}
 
+	/**
+	 * This toggles the active state of a tab at a given index.
+	 *
+	 * @param {number} index is the index of the tab
+	 * @param {boolean} isActive describes if the tab schould be active
+	 */
 	toggle(index, isActive) {
 		var
 			button = this._buttons.eq(index),
@@ -227,6 +358,11 @@ class View extends BaseView {
 		}
 	}
 
+	/**
+	 * This toggles active states of all existing tabs.
+	 *
+	 * @param {boolean} isActive describes if the tab schould be active
+	 */
 	toggleAll(isActive) {
 		this._buttons.each(index => {
 			this.toggle(index, isActive);

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -144,7 +144,7 @@ class View extends BaseView {
 		}
 
 		if (this.isMultiselectable) {
-			this.toggle(value, !this.isSelectedTabAt(value));
+			this.toggle(value, !this.isSelected(value));
 		} else {
 			if (this.options.toggleable && value === this._selected) {
 				value = -1;
@@ -309,7 +309,7 @@ class View extends BaseView {
 	 * @param {number} index is the index of the tab to check
 	 * @return {boolean} describes if the tab is selected (not collapsed)
 	 */
-	isSelectedTabAt(index) {
+	isSelected(index) {
 		if (index < 0 || index >= this._buttons.length) {
 			return false;
 		}
@@ -335,7 +335,7 @@ class View extends BaseView {
 
 		if (!_.isBoolean(isSelected)) {
 			// If isSelected is not defined, this is the toggling feature...
-			isSelected = !this.isSelectedTabAt(index);
+			isSelected = !this.isSelected(index);
 		}
 
 		tab
@@ -480,6 +480,9 @@ class View extends BaseView {
 
 	_onFocus(event) {
 		var button = $(event.currentTarget);
+		// Toggle selected state depending on event type:
+		// * event.type === 'focus' ---> selected
+		// * event.type === 'blur' ---> not selected
 		button.attr(ATTR_ARIA_SELECTED, event.type === 'focus');
 	}
 

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -483,7 +483,10 @@ class View extends BaseView {
 		event.stopPropagation();
 
 		if (!this.isDisabledTabAt(index)) {
-			this.toggle(index);
+			this.toggle(
+				index,
+				(this.isMultiselectable || this.isToggleable) ? undefined : true
+			);
 
 			this.trigger('change', {
 				instance: this,

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -31,10 +31,10 @@ var
 	KEY_HOME = 36,
 	DEFAULTS = {
 		root: undefined,
-		active: 0,
+		selected: 0,
 		toggleable: false,
 		multiselectable: false,
-		classActive: 'is-active',
+		classSelected: 'is-selected',
 		classCollapsed: 'is-collapsed',
 		classDisabled: 'is-disabled'
 	}
@@ -48,7 +48,7 @@ var
  * your stylesheets to enable the visual changes:
  *
  * * `.is-collapsed` hides closed tab panels
- * * `.is-active` marks the active tab button
+ * * `.is-selected` marks the selected tab button
  * * `.is-disabled` use this class to visually disable a tab
  *
  * Tabs and accordions have quite the same functionality. They only differ in
@@ -107,10 +107,10 @@ class View extends BaseView {
 	 * @param {object} options.el The element reference for a backbone.view
 	 * @param {element|$element} options.root A reference for the view to look up for tab panels. By default this is undefined which means the lookup will be the whole DOM.
 	 * @param {string} options.selectorButton is the selector for tab buttons
-	 * @param {number} options.number is the initial active tab index. Default is 1
-	 * @param {boolean} options.toggleable defines if a tabs state is toggleable between active and inactive. This is mostly required for accordion behaviours. Default is false
+	 * @param {number} options.selected is the initial selected tab index. Default is 1
+	 * @param {boolean} options.toggleable defines if a tabs state is toggleable between selected and not. This is mostly required for accordion behaviours. Default is false
 	 * @param {boolean} options.multiselectable allows the activation of more than one tabs. Default is false
-	 * @param {string} options.classActive the classname to use for active tab buttons. Default value is 'is-active'
+	 * @param {string} options.classSelected the classname to use for selected tab buttons. Default value is 'is-selected'
 	 * @param {string} options.classCollapsed the classname to use for collapsed tab panels. Default value is 'is-collapsed'
 	 * @param {string} options.classDisabled the classname to use for disabled tab elements. Default value is 'is-disabled'
 	 */
@@ -130,30 +130,30 @@ class View extends BaseView {
 	}
 
 	/**
-	 * Gets and sets the active index of tabs.
+	 * Gets and sets the selected index of tabs.
 	 *
 	 * @return {number} index of tab
 	 */
-	get active() {
-		return this._active;
+	get selected() {
+		return this._selected;
 	}
 
-	set active(value) {
+	set selected(value) {
 		if (this.isDisabledTabAt(value)) {
 			return;
 		}
 
 		if (this.isMultiselectable) {
-			this.toggle(value, !this.isActiveTabAt(value));
+			this.toggle(value, !this.isSelectedTabAt(value));
 		} else {
-			if (this.options.toggleable && value === this._active) {
+			if (this.options.toggleable && value === this._selected) {
 				value = -1;
 			}
 
-			if (value !== this._active && value < this._buttons.length) {
+			if (value !== this._selected && value < this._buttons.length) {
 				this._buttons.each(index => {
 					this.toggle(index, value === index);
-					this._active = value;
+					this._selected = value;
 				});
 			}
 		}
@@ -219,7 +219,7 @@ class View extends BaseView {
 			.on(EVENT_CLICK, this._onIgnoredClick);
 
 		this.toggleAll(false);
-		this.active = this.options.active;
+		this.selected = this.options.selected;
 
 		return this;
 	}
@@ -304,27 +304,27 @@ class View extends BaseView {
 	}
 
 	/**
-	 * Returns if the tab at the given index is active (not collapsed).
+	 * Returns if the tab at the given index is selected (not collapsed).
 	 *
 	 * @param {number} index is the index of the tab to check
-	 * @return {boolean} describes if the tab is active (not collapsed)
+	 * @return {boolean} describes if the tab is selected (not collapsed)
 	 */
-	isActiveTabAt(index) {
+	isSelectedTabAt(index) {
 		if (index < 0 || index >= this._buttons.length) {
 			return false;
 		}
 
 		return this.getTabAt(index)
-			.hasClass(this.options.classActive);
+			.hasClass(this.options.classSelected);
 	}
 
 	/**
-	 * This toggles the active state of a tab at a given index.
+	 * This toggles the selected state of a tab at a given index.
 	 *
 	 * @param {number} index is the index of the tab
-	 * @param {boolean} isActive describes if the tab schould be active
+	 * @param {boolean} isSelected describes if the tab should be selected
 	 */
-	toggle(index, isActive) {
+	toggle(index, isSelected) {
 		var
 			button = this._buttons.eq(index),
 			buttonId = button.attr('id') || this.getUniqueId(true),
@@ -333,39 +333,39 @@ class View extends BaseView {
 			tab = button.parent()
 		;
 
-		if (!_.isBoolean(isActive)) {
-			// If isActive is not defined, this is the toggling feature...
-			isActive = !this.isActiveTabAt(index);
+		if (!_.isBoolean(isSelected)) {
+			// If isSelected is not defined, this is the toggling feature...
+			isSelected = !this.isSelectedTabAt(index);
 		}
 
 		tab
-			.toggleClass(this.options.classActive, isActive);
+			.toggleClass(this.options.classSelected, isSelected);
 
 		button
 			.attr('id', buttonId)
 			.attr(ATTR_ROLE, 'tab')
-			.attr(ATTR_ARIA_EXPANDED, isActive)
+			.attr(ATTR_ARIA_EXPANDED, isSelected)
 			.attr(ATTR_ARIA_CONTROLS, selector.replace('#', ''));
 
 		panel
 			.attr(ATTR_ROLE, 'tabpanel')
-			.attr(ATTR_AIRA_HIDDEN, (!isActive).toString())
+			.attr(ATTR_AIRA_HIDDEN, (!isSelected).toString())
 			.attr(ATTR_AIRA_LABELLEDBY, buttonId)
-			.toggleClass(this.options.classCollapsed, !isActive);
+			.toggleClass(this.options.classCollapsed, !isSelected);
 
-		if (isActive) {
-			this._active = index;
+		if (isSelected) {
+			this._selected = index;
 		}
 	}
 
 	/**
-	 * This toggles active states of all existing tabs.
+	 * This toggles selected states of all existing tabs.
 	 *
-	 * @param {boolean} isActive describes if the tab schould be active
+	 * @param {boolean} isSelected describes if the tab schould be selected
 	 */
-	toggleAll(isActive) {
+	toggleAll(isSelected) {
 		this._buttons.each(index => {
-			this.toggle(index, isActive);
+			this.toggle(index, isSelected);
 		});
 	}
 
@@ -408,16 +408,16 @@ class View extends BaseView {
 		event.stopPropagation();
 
 		if (!this.isDisabledTabAt(index)) {
-			this.active = index;
+			this.selected = index;
 
 			this.trigger('change', {
 				instance: this,
-				active: this.active
+				selected: this.selected
 			});
 
 			this.context.dispatch('tabs:change', {
 				instance: this,
-				active: this.active
+				selected: this.selected
 			});
 		}
 	}
@@ -430,7 +430,7 @@ class View extends BaseView {
 		;
 
 		if (button.length > 0) {
-			this.active = this._buttons.index(button[0]);
+			this.selected = this._buttons.index(button[0]);
 		}
 	}
 
@@ -450,7 +450,7 @@ class View extends BaseView {
 				if (this.isMultiselectable) {
 					this.toggle(index);
 				} else {
-					this.active = index;
+					this.selected = index;
 				}
 				break;
 			case KEY_ARROW_LEFT:

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -68,7 +68,7 @@ class View extends BaseView {
 		}
 
 		if (this.isMultiselectable) {
-			this._toggle(value, !this.isActiveTabAt(value));
+			this.toggle(value, !this.isActiveTabAt(value));
 		} else {
 			if (this.options.toggleable && value === this._active) {
 				value = -1;
@@ -76,7 +76,7 @@ class View extends BaseView {
 
 			if (value !== this._active && value < this._buttons.length) {
 				this._buttons.each(index => {
-					this._toggle(index, value === index);
+					this.toggle(index, value === index);
 					this._active = value;
 				});
 			}
@@ -132,7 +132,7 @@ class View extends BaseView {
 		this._ignoredButtons
 			.on(EVENT_CLICK, this._onIgnoredClick);
 
-		this.collapseAll();
+		this.toggleAll(false);
 		this.active = this.options.active;
 
 		return this;
@@ -193,31 +193,7 @@ class View extends BaseView {
 			.hasClass(this.options.classActive);
 	}
 
-	collapse(index) {
-		this._toggle(index, false);
-	}
-
-	collapseAll() {
-		this._buttons.each(index => {
-			this._toggle(index, false);
-		});
-	}
-
-	_disableTabAt(index, disabled) {
-		this.getTabAt(index).toggleClass(this.options.classDisabled, disabled);
-
-		if (disabled) {
-			this.getButtonAt(index)
-				.attr(ATTR_AIRA_DISABLED, 'true')
-				.attr(ATTR_TABINDEX, '-1');
-		} else {
-			this.getButtonAt(index)
-				.removeAttr(ATTR_AIRA_DISABLED)
-				.removeAttr(ATTR_TABINDEX);
-		}
-	}
-
-	_toggle(index, isActive) {
+	toggle(index, isActive) {
 		var
 			button = this._buttons.eq(index),
 			buttonId = button.attr('id') || this.getUniqueId(true),
@@ -248,6 +224,26 @@ class View extends BaseView {
 
 		if (isActive) {
 			this._active = index;
+		}
+	}
+
+	toggleAll(isActive) {
+		this._buttons.each(index => {
+			this.toggle(index, isActive);
+		});
+	}
+
+	_disableTabAt(index, disabled) {
+		this.getTabAt(index).toggleClass(this.options.classDisabled, disabled);
+
+		if (disabled) {
+			this.getButtonAt(index)
+				.attr(ATTR_AIRA_DISABLED, 'true')
+				.attr(ATTR_TABINDEX, '-1');
+		} else {
+			this.getButtonAt(index)
+				.removeAttr(ATTR_AIRA_DISABLED)
+				.removeAttr(ATTR_TABINDEX);
 		}
 	}
 
@@ -316,7 +312,7 @@ class View extends BaseView {
 				event.preventDefault();
 
 				if (this.isMultiselectable) {
-					this._toggle(index);
+					this.toggle(index);
 				} else {
 					this.active = index;
 				}

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -16,7 +16,7 @@ var
 	ATTR_AIRA_LABELLEDBY = 'aria-labelledby',
 	ATTR_ARIA_EXPANDED = 'aria-expanded',
 	ATTR_ARIA_DISABLED = 'aria-disabled',
-	ATTR_ARIA_MULTISELECTABLE = 'multiselectable',
+	ATTR_ARIA_MULTISELECTABLE = 'aria-multiselectable',
 	ATTR_TABINDEX = 'tabindex',
 	EVENT_CLICK = 'click',
 	EVENT_KEYDOWN = 'keydown',

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -160,6 +160,15 @@ class View extends BaseView {
 	}
 
 	/**
+	 * Returns if the toggleable option is set or not.
+	 *
+	 * @return {Boolean} defines the toggleable state.
+	 */
+	get isToggleable() {
+		return this.options.toggleable;
+	}
+
+	/**
 	 * Retuns if the tabs module is multiselectable.
 	 *
 	 * @return {boolean} defines the multiselectable state

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -8,6 +8,7 @@ import UniqueMixin from 'picnic/mixins/Unique';
 
 
 var
+	SELECTOR_BUTTON = '[href^="#"]',
 	ATTR_ROLE = 'role',
 	ATTR_ARIA_SELECTED = 'aria-selected',
 	ATTR_ARIA_CONTROLS = 'aria-controls',
@@ -30,7 +31,6 @@ var
 	KEY_HOME = 36,
 	DEFAULTS = {
 		root: undefined,
-		selectorButton: 'a[href^="#"]',
 		active: 0,
 		toggleable: false,
 		multiselectable: false,
@@ -94,13 +94,24 @@ class View extends BaseView {
 	}
 
 	render() {
+		this._buttons = $();
+		this._ignoredButtons = $();
+
 		this.$el
 			.attr(ATTR_ROLE, 'tablist')
-			.attr(ATTR_ARIA_MULTISELECTABLE, this.isMultiselectable);
+			.attr(ATTR_ARIA_MULTISELECTABLE, this.isMultiselectable)
+			.find(SELECTOR_BUTTON)
+				.each((index, button) => {
+					// Find duplicates in parsed button list with same href:
+					var count = this._buttons
+						.filter('[href="' + $(button).attr('href') + '"]').length;
 
-		this._lookupButtons();
-		this.collapseAll();
-		this.active = this.options.active;
+					if (count === 0) {
+						this._buttons.push(button);
+					} else {
+						this._ignoredButtons.push(button);
+					}
+				});
 
 		this._buttons
 			// Check disabled state of each tab...
@@ -120,6 +131,9 @@ class View extends BaseView {
 
 		this._ignoredButtons
 			.on(EVENT_CLICK, this._onIgnoredClick);
+
+		this.collapseAll();
+		this.active = this.options.active;
 
 		return this;
 	}
@@ -201,24 +215,6 @@ class View extends BaseView {
 				.removeAttr(ATTR_AIRA_DISABLED)
 				.removeAttr(ATTR_TABINDEX);
 		}
-	}
-
-	_lookupButtons() {
-		this._buttons = $();
-		this._ignoredButtons = $();
-
-		this.$el
-			.find(this.options.selectorButton)
-			.each((index, button) => {
-				var count = this._buttons
-					.filter('[href="' + $(button).attr('href') + '"]').length;
-
-				if (count === 0) {
-					this._buttons.push(button);
-				} else {
-					this._ignoredButtons.push(button);
-				}
-			});
 	}
 
 	_toggle(index, isActive) {

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -72,7 +72,7 @@ var
  *		import Tabs from 'picnic/tabs/views/Tabs';
  *
  *		var tabs = new Tabs({
- *			el: $('.tabs')[0],
+ *			el: $('.tabs').get(0),
  *			context: app.context
  *		}).render();
  *
@@ -91,7 +91,7 @@ var
  *		import Tabs from 'picnic/tabs/views/Tabs';
  *
  *		var accordion = new Tabs({
- *			el: $('.accordion')[0],
+ *			el: $('.accordion').get(0),
  *			context: app.context,
  *			toggleable: true
  *		}).render();
@@ -108,7 +108,7 @@ class View extends BaseView {
 	 * @param {element|$element} options.root A reference for the view to look up for tab panels. By default this is null which means the lookup will be the whole DOM.
 	 * @param {string} options.selectorButton is the selector for tab buttons
 	 * @param {number} options.selected is the initial selected tab index. Default is [0]. When initialize with no selection, use an empty array: [].
-	 * @param {boolean} options.toggleable defines if a tabs state is toggleable between selected and not. This is mostly required for accordion behaviours. Default is false
+	 * @param {boolean} options.toggleable defines if a tabs state is toggleable between selected and not. This means if enabled, a active tab can be collapsed by second user click on the same tab. This is mostly required for accordion behaviours. Default is false
 	 * @param {boolean} options.multiselectable allows the activation of more than one tabs. Default is false
 	 * @param {string} options.classSelected the classname to use for selected tab buttons. Default value is 'is-selected'
 	 * @param {string} options.classCollapsed the classname to use for collapsed tab panels. Default value is 'is-collapsed'

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -15,7 +15,7 @@ var
 	ATTR_AIRA_HIDDEN = 'aria-hidden',
 	ATTR_AIRA_LABELLEDBY = 'aria-labelledby',
 	ATTR_ARIA_EXPANDED = 'aria-expanded',
-	ATTR_AIRA_DISABLED = 'aria-disabled',
+	ATTR_ARIA_DISABLED = 'aria-disabled',
 	ATTR_ARIA_MULTISELECTABLE = 'multiselectable',
 	ATTR_TABINDEX = 'tabindex',
 	EVENT_CLICK = 'click',
@@ -374,11 +374,11 @@ class View extends BaseView {
 
 		if (disabled) {
 			this.getButtonAt(index)
-				.attr(ATTR_AIRA_DISABLED, 'true')
+				.attr(ATTR_ARIA_DISABLED, 'true')
 				.attr(ATTR_TABINDEX, '-1');
 		} else {
 			this.getButtonAt(index)
-				.removeAttr(ATTR_AIRA_DISABLED)
+				.removeAttr(ATTR_ARIA_DISABLED)
 				.removeAttr(ATTR_TABINDEX);
 		}
 	}

--- a/src/tabs/views/Tabs.js
+++ b/src/tabs/views/Tabs.js
@@ -1,0 +1,360 @@
+import $ from 'jquery';
+import _ from 'underscore';
+import BaseView from 'picnic/core/views/Base';
+import UniqueMixin from 'picnic/mixins/Unique';
+
+
+// Inspired by: http://www.oaa-accessibility.org/examplep/accordian1/
+
+
+var
+	ATTR_ROLE = 'role',
+	ATTR_ARIA_SELECTED = 'aria-selected',
+	ATTR_ARIA_CONTROLS = 'aria-controls',
+	ATTR_AIRA_HIDDEN = 'aria-hidden',
+	ATTR_AIRA_LABELLEDBY = 'aria-labelledby',
+	ATTR_ARIA_EXPANDED = 'aria-expanded',
+	ATTR_AIRA_DISABLED = 'aria-disabled',
+	ATTR_ARIA_MULTISELECTABLE = 'multiselectable',
+	ATTR_TABINDEX = 'tabindex',
+	EVENT_CLICK = 'click',
+	EVENT_KEYDOWN = 'keydown',
+	EVENT_FOCUS = 'focus blur',
+	KEY_ENTER = 13,
+	KEY_SPACE = 32,
+	KEY_ARROW_LEFT = 37,
+	KEY_ARROW_UP = 38,
+	KEY_ARROW_RIGHT = 39,
+	KEY_ARROW_DOWN = 40,
+	KEY_END = 35,
+	KEY_HOME = 36,
+	DEFAULTS = {
+		root: undefined,
+		selectorButton: 'a[href^="#"]',
+		active: 0,
+		toggleable: false,
+		multiselectable: false,
+		classActive: 'is-active',
+		classCollapsed: 'is-collapsed',
+		classDisabled: 'is-disabled'
+	}
+;
+
+
+class View extends BaseView {
+
+	constructor(options) {
+		super($.extend({}, DEFAULTS, options));
+
+		// Load mixins:
+		new UniqueMixin(this);
+
+		_.bindAll(
+			this,
+			'_onClick',
+			'_onIgnoredClick',
+			'_onKeydown',
+			'_onFocus'
+		);
+	}
+
+	get active() {
+		return this._active;
+	}
+
+	set active(value) {
+		if (this.isDisabledTabAt(value)) {
+			return;
+		}
+
+		if (this.isMultiselectable) {
+			this._toggle(value, !this.isActiveTabAt(value));
+		} else {
+			if (this.options.toggleable && value === this._active) {
+				value = -1;
+			}
+
+			if (value !== this._active && value < this._buttons.length) {
+				this._buttons.each(index => {
+					this._toggle(index, value === index);
+					this._active = value;
+				});
+			}
+		}
+	}
+
+	get isMultiselectable() {
+		// This caches the return value of the initial call:
+		this._isMultiselectable = this._isMultiselectable || (function() {
+			return this.options.multiselectable ||
+				(this.$el.attr(ATTR_ARIA_MULTISELECTABLE) || '').toLowerCase() === 'true';
+		}.bind(this))();
+
+		return this._isMultiselectable;
+	}
+
+	render() {
+		this.$el
+			.attr(ATTR_ROLE, 'tablist')
+			.attr(ATTR_ARIA_MULTISELECTABLE, this.isMultiselectable);
+
+		this._lookupButtons();
+		this.collapseAll();
+		this.active = this.options.active;
+
+		this._buttons
+			// Check disabled state of each tab...
+			.each(index => {
+				if (this.isDisabledTabAt(index)) {
+					// When tab is disabled by class, force aria and other updates
+					// on tab and button to keep consistent accessible state...
+					this.disableTabAt(index);
+				}
+			})
+			// Buttons are by default not selected
+			.attr(ATTR_ARIA_SELECTED, 'false')
+			// Bind click events
+			.on(EVENT_CLICK, this._onClick)
+			.on(EVENT_KEYDOWN, this._onKeydown)
+			.on(EVENT_FOCUS, this._onFocus);
+
+		this._ignoredButtons
+			.on(EVENT_CLICK, this._onIgnoredClick);
+
+		return this;
+	}
+
+	destroy() {
+		if (this._buttons) {
+			this._buttons
+				.off(EVENT_CLICK, this._onClick)
+				.off(EVENT_KEYDOWN, this._onKeydown)
+				.off(EVENT_FOCUS, this._onFocus);
+
+			this._buttons = undefined;
+			delete(this._buttons);
+		}
+
+		if (this._ignoredButtons) {
+			this._ignoredButtons
+				.off(EVENT_CLICK, this._onIgnoredClick);
+			this._ignoredButtons = undefined;
+			delete(this._ignoredButtons);
+		}
+
+		super.destroy();
+	}
+
+	getTabAt(index) {
+		return this._buttons.eq(index).parent();
+	}
+
+	getButtonAt(index) {
+		return this._buttons.eq(index);
+	}
+
+	enableTabAt(index) {
+		this._disableTabAt(index, false);
+	}
+
+	disableTabAt(index) {
+		this._disableTabAt(index, true);
+	}
+
+	isDisabledTabAt(index) {
+		if (index < 0 || index >= this._buttons.length) {
+			return false;
+		}
+
+		return this.getTabAt(index)
+			.hasClass(this.options.classDisabled);
+	}
+
+	isActiveTabAt(index) {
+		if (index < 0 || index >= this._buttons.length) {
+			return false;
+		}
+
+		return this.getTabAt(index)
+			.hasClass(this.options.classActive);
+	}
+
+	collapse(index) {
+		this._toggle(index, false);
+	}
+
+	collapseAll() {
+		this._buttons.each(index => {
+			this._toggle(index, false);
+		});
+	}
+
+	_disableTabAt(index, disabled) {
+		this.getTabAt(index).toggleClass(this.options.classDisabled, disabled);
+
+		if (disabled) {
+			this.getButtonAt(index)
+				.attr(ATTR_AIRA_DISABLED, 'true')
+				.attr(ATTR_TABINDEX, '-1');
+		} else {
+			this.getButtonAt(index)
+				.removeAttr(ATTR_AIRA_DISABLED)
+				.removeAttr(ATTR_TABINDEX);
+		}
+	}
+
+	_lookupButtons() {
+		this._buttons = $();
+		this._ignoredButtons = $();
+
+		this.$el
+			.find(this.options.selectorButton)
+			.each((index, button) => {
+				var count = this._buttons
+					.filter('[href="' + $(button).attr('href') + '"]').length;
+
+				if (count === 0) {
+					this._buttons.push(button);
+				} else {
+					this._ignoredButtons.push(button);
+				}
+			});
+	}
+
+	_toggle(index, isActive) {
+		var
+			button = this._buttons.eq(index),
+			buttonId = button.attr('id') || this.getUniqueId(true),
+			selector = button.attr('href'),
+			panel = $(selector, this.options.root),
+			tab = button.parent()
+		;
+
+		if (!_.isBoolean(isActive)) {
+			// If isActive is not defined, this is the toggling feature...
+			isActive = !this.isActiveTabAt(index);
+		}
+
+		tab
+			.toggleClass(this.options.classActive, isActive);
+
+		button
+			.attr('id', buttonId)
+			.attr(ATTR_ROLE, 'tab')
+			.attr(ATTR_ARIA_EXPANDED, isActive)
+			.attr(ATTR_ARIA_CONTROLS, selector.replace('#', ''));
+
+		panel
+			.attr(ATTR_ROLE, 'tabpanel')
+			.attr(ATTR_AIRA_HIDDEN, (!isActive).toString())
+			.attr(ATTR_AIRA_LABELLEDBY, buttonId)
+			.toggleClass(this.options.classCollapsed, !isActive);
+
+		if (isActive) {
+			this._active = index;
+		}
+	}
+
+	_focusButtonAt(index, direction = 1) {
+		if (Math.abs(direction) !== 1) {
+			throw new Error('Pass a direction of 1 or -1 for focusing a button.');
+		}
+
+		if (index < 0) {
+			index = this._buttons.length - 1;
+		} else if (index >= this._buttons.length) {
+			index = 0;
+		}
+
+		if (this.isDisabledTabAt(index)) {
+			return this._focusButtonAt(index + direction, direction);
+		}
+
+		this._buttons.eq(index).focus();
+		return true;
+	}
+
+	_onClick(event) {
+		var index = this._buttons.index(event.currentTarget);
+		event.preventDefault();
+		event.stopPropagation();
+
+		if (!this.isDisabledTabAt(index)) {
+			this.active = index;
+
+			this.trigger('change', {
+				instance: this,
+				active: this.active
+			});
+
+			this.context.dispatch('tabs:change', {
+				instance: this,
+				active: this.active
+			});
+		}
+	}
+
+	_onIgnoredClick(event) {
+		var
+			target = $(event.currentTarget),
+			href = target.attr('href'),
+			button = this._buttons.filter('[href="' + href + '"]')
+		;
+
+		if (button.length > 0) {
+			this.active = this._buttons.index(button[0]);
+		}
+	}
+
+	_onKeydown(event) {
+		var index = this._buttons.index(event.currentTarget);
+
+		if (event.altKey) {
+			// do nothing...
+			return;
+		}
+
+		switch (event.which) {
+			case KEY_ENTER:
+			case KEY_SPACE:
+				event.preventDefault();
+
+				if (this.isMultiselectable) {
+					this._toggle(index);
+				} else {
+					this.active = index;
+				}
+				break;
+			case KEY_ARROW_LEFT:
+			case KEY_ARROW_UP:
+				event.preventDefault();
+				this._focusButtonAt(index - 1 , -1);
+
+				break;
+			case KEY_ARROW_RIGHT:
+			case KEY_ARROW_DOWN:
+				event.preventDefault();
+
+				this._focusButtonAt(index + 1, 1);
+				break;
+			case KEY_END:
+				event.preventDefault();
+
+				this._focusButtonAt(this._buttons.length - 1, -1);
+				break;
+			case KEY_HOME:
+				event.preventDefault();
+
+				this._focusButtonAt(0, 1);
+				break;
+		}
+	}
+
+	_onFocus(event) {
+		var button = $(event.currentTarget);
+		button.attr(ATTR_ARIA_SELECTED, event.type === 'focus');
+	}
+
+}
+
+export default View;

--- a/tests/modules.js
+++ b/tests/modules.js
@@ -51,6 +51,9 @@ import TrackingGoogleTagManagerTrackPageview from 'picnic/googletagmanager/comma
 import TrackingGoogleTagManagerTrackEvent from 'picnic/googletagmanager/commands/TrackEvent';
 import TrackingGoogleTagManagerTrackSocial from 'picnic/googletagmanager/commands/TrackSocial';
 
+import Tabs from 'picnic/Tabs';
+import TabsView from 'picnic/tabs/views/Tabs';
+
 import Tabfocus from 'picnic/Tabfocus';
 import TabfocusInitialize from 'picnic/tabfocus/commands/Initialize';
 
@@ -113,4 +116,8 @@ QUnit.test('should export the googletagmanager module', function(assert) {
 
 QUnit.test('should export the tabfocus initialize command', function(assert) {
 	assert.equal(Tabfocus, TabfocusInitialize);
+});
+
+QUnit.test('should export the tabs view', function(assert) {
+	assert.equal(Tabs, TabsView);
 });

--- a/tests/tabs/views/fixtures/tabs.html
+++ b/tests/tabs/views/fixtures/tabs.html
@@ -1,0 +1,9 @@
+<ul class="tabs">
+	<li><a href="#tab-a">Tab A</a></li>
+	<li><a href="#tab-b">Tab B</a></li>
+	<li><a href="#tab-c">Tab C</a></li>
+</ul>
+
+<div id="tab-a"><h2>Tab A</h2></div>
+<div id="tab-b"><h2>Tab B</h2></div>
+<div id="tab-c"><h2>Tab C</h2></div>

--- a/tests/tabs/views/tabs.js
+++ b/tests/tabs/views/tabs.js
@@ -143,7 +143,7 @@ QUnit.test('should toggle selected state by property "selected"', function(asser
 	assert.notOk($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by classname');
 });
 
-QUnit.test('should be toggleable by option and click on button', function(assert) {
+QUnit.test('should be toggleable by option and using click on button', function(assert) {
 	new View({
 		el: this.root.find('.tabs')[0],
 		context: this.context,
@@ -171,7 +171,7 @@ QUnit.test('should be toggleable by option and click on button', function(assert
 	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by classname');
 });
 
-QUnit.test('should be toggleable by option and click on button', function(assert) {
+QUnit.test('should be toggleable by option and using selected property', function(assert) {
 	var view = new View({
 		el: this.root.find('.tabs')[0],
 		context: this.context,
@@ -200,6 +200,20 @@ QUnit.test('should be toggleable by option and click on button', function(assert
 	// Container 3:
 	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
 	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by classname');
+});
+
+QUnit.test('should return toggleable state by getter', function(assert) {
+	var
+		options = {
+			el: this.root.find('.tabs')[0],
+			context: this.context
+		},
+		enabled = new View($.extend({}, options, {toggleable: true})).render(),
+		disabled = new View($.extend({}, options, {toggleable: false})).render()
+	;
+
+	assert.ok(enabled.isToggleable);
+	assert.notOk(disabled.isToggleable);
 });
 
 QUnit.test('should be initially disabled when passing -1 for selected property', function(assert) {

--- a/tests/tabs/views/tabs.js
+++ b/tests/tabs/views/tabs.js
@@ -31,9 +31,9 @@ QUnit.test('should render accessible elements', function(assert) {
 	assert.equal(this.view.$el.attr('multiselectable'), 'false', 'the list element should be initially marked as not "multiselectable"');
 
 	// List entries
-	assert.ok(this.view.$el.find('> li').eq(0).hasClass('is-active'), 'the first list element is active by class name');
-	assert.notOk(this.view.$el.find('> li').eq(1).hasClass('is-active'), 'the secend list element is not active by class name');
-	assert.notOk(this.view.$el.find('> li').eq(2).hasClass('is-active'), 'the third list element is not active by class name');
+	assert.ok(this.view.$el.find('> li').eq(0).hasClass('is-selected'), 'the first list element is selected by classname');
+	assert.notOk(this.view.$el.find('> li').eq(1).hasClass('is-selected'), 'the secend list element is not selected by classname');
+	assert.notOk(this.view.$el.find('> li').eq(2).hasClass('is-selected'), 'the third list element is not selected by classname');
 
 	// Button 1:
 	assert.equal(typeof $('a[href="#tab-a"]').attr('id'), 'string', 'the first button should have an id');
@@ -65,19 +65,19 @@ QUnit.test('should render accessible elements', function(assert) {
 	assert.equal($('#tab-a').attr('role'), 'tabpanel', 'the first container should be marked as "tabpanel"');
 	assert.equal($('#tab-a').attr('aria-hidden'), 'false', 'the first container should be not hidden');
 	assert.equal($('#tab-a').attr('aria-labelledby'), $('a[href="#tab-a"]').attr('id'), 'the first container should be labeled by the first button');
-	assert.notOk($('#tab-a').hasClass('is-collapsed'), 'the first container is not collapesed by class name');
+	assert.notOk($('#tab-a').hasClass('is-collapsed'), 'the first container is not collapesed by classname');
 
 	// Container 2:
 	assert.equal($('#tab-b').attr('role'), 'tabpanel', 'the second container should be marked as "tabpanel"');
 	assert.equal($('#tab-b').attr('aria-hidden'), 'true', 'the second container should be hidden');
 	assert.equal($('#tab-b').attr('aria-labelledby'), $('a[href="#tab-b"]').attr('id'), 'the second container should be labeled by the second button');
-	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by class name');
+	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by classname');
 
 	// Container 3:
 	assert.equal($('#tab-c').attr('role'), 'tabpanel', 'the third container should be marked as "tabpanel"');
 	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
 	assert.equal($('#tab-c').attr('aria-labelledby'), $('a[href="#tab-c"]').attr('id'), 'the third container should be labeled by the third button');
-	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by classname');
 });
 
 QUnit.test('should return correct list entry by index', function(assert) {
@@ -98,7 +98,7 @@ QUnit.test('should return correct button by index', function(assert) {
 	assert.equal(this.view.getButtonAt(4711)[0], undefined);
 });
 
-QUnit.test('should toggle active state by click on button', function(assert) {
+QUnit.test('should toggle selected state by click on button', function(assert) {
 	this.view.render();
 
 	$('a[href="#tab-b"]').trigger('click');
@@ -110,20 +110,20 @@ QUnit.test('should toggle active state by click on button', function(assert) {
 
 	// Container 1:
 	assert.equal($('#tab-a').attr('aria-hidden'), 'true', 'the first container should be not hidden');
-	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by class name');
+	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by classname');
 
 	// Container 2:
 	assert.equal($('#tab-b').attr('aria-hidden'), 'false', 'the second container should not be hidden');
-	assert.notOk($('#tab-b').hasClass('is-collapsed'), 'the second container is not collapesed by class name');
+	assert.notOk($('#tab-b').hasClass('is-collapsed'), 'the second container is not collapesed by classname');
 
 	// Container 3:
 	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
-	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by classname');
 });
 
-QUnit.test('should toggle active state by property "active"', function(assert) {
+QUnit.test('should toggle selected state by property "selected"', function(assert) {
 	this.view.render();
-	this.view.active = 2; // third button / container
+	this.view.selected = 2; // third button / container
 
 	// Buttons:
 	assert.equal($('a[href="#tab-a"]').attr('aria-expanded'), 'false', 'the first button should not be expanded by "aria-expanded"');
@@ -132,15 +132,15 @@ QUnit.test('should toggle active state by property "active"', function(assert) {
 
 	// Container 1:
 	assert.equal($('#tab-a').attr('aria-hidden'), 'true', 'the first container should be hidden');
-	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by class name');
+	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by classname');
 
 	// Container 2:
 	assert.equal($('#tab-b').attr('aria-hidden'), 'true', 'the second container should be hidden');
-	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is not collapesed by class name');
+	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is not collapesed by classname');
 
 	// Container 3:
 	assert.equal($('#tab-c').attr('aria-hidden'), 'false', 'the third container should not be hidden');
-	assert.notOk($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+	assert.notOk($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by classname');
 });
 
 QUnit.test('should be toggleable by option and click on button', function(assert) {
@@ -150,7 +150,7 @@ QUnit.test('should be toggleable by option and click on button', function(assert
 		toggleable: true
 	}).render();
 
-	// a click on a previously active button...
+	// a click on a previously selected button...
 	$('a[href="#tab-a"]').trigger('click');
 
 	// Buttons:
@@ -160,15 +160,15 @@ QUnit.test('should be toggleable by option and click on button', function(assert
 
 	// Container 1:
 	assert.equal($('#tab-a').attr('aria-hidden'), 'true', 'the first container should be not hidden');
-	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by class name');
+	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by classname');
 
 	// Container 2:
 	assert.equal($('#tab-b').attr('aria-hidden'), 'true', 'the second container should not be hidden');
-	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by class name');
+	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by classname');
 
 	// Container 3:
 	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
-	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by classname');
 });
 
 QUnit.test('should be toggleable by option and click on button', function(assert) {
@@ -180,9 +180,9 @@ QUnit.test('should be toggleable by option and click on button', function(assert
 
 	view.render();
 
-	// remove active state from all buttons and containers, by setting the
-	// active index twice...
-	view.active = view.active;
+	// remove selected state from all buttons and containers, by setting the
+	// selected index twice...
+	view.selected = view.selected;
 
 	// Buttons:
 	assert.equal($('a[href="#tab-a"]').attr('aria-selected'), 'false', 'the first button should not be selected by "aria-selected"');
@@ -191,22 +191,22 @@ QUnit.test('should be toggleable by option and click on button', function(assert
 
 	// Container 1:
 	assert.equal($('#tab-a').attr('aria-hidden'), 'true', 'the first container should be not hidden');
-	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by class name');
+	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by classname');
 
 	// Container 2:
 	assert.equal($('#tab-b').attr('aria-hidden'), 'true', 'the second container should not be hidden');
-	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by class name');
+	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by classname');
 
 	// Container 3:
 	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
-	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by classname');
 });
 
-QUnit.test('should be initially disabled when passing -1 for active property', function(assert) {
+QUnit.test('should be initially disabled when passing -1 for selected property', function(assert) {
 	var view = new View({
 		el: this.root.find('.tabs')[0],
 		context: this.context,
-		active: -1
+		selected: -1
 	});
 
 	view.render();
@@ -218,15 +218,15 @@ QUnit.test('should be initially disabled when passing -1 for active property', f
 
 	// Container 1:
 	assert.equal($('#tab-a').attr('aria-hidden'), 'true', 'the first container should be not hidden');
-	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by class name');
+	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by classname');
 
 	// Container 2:
 	assert.equal($('#tab-b').attr('aria-hidden'), 'true', 'the second container should not be hidden');
-	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by class name');
+	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by classname');
 
 	// Container 3:
 	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
-	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by classname');
 });
 
 QUnit.test('should fire "change" event when user click through tabs', function(assert) {
@@ -239,7 +239,7 @@ QUnit.test('should fire "change" event when user click through tabs', function(a
 	assert.ok(callback.calledOnce);
 	assert.deepEqual(callback.getCall(0).args[0], {
 		instance: this.view,
-		active: 1
+		selected: 1
 	});
 });
 
@@ -254,7 +254,7 @@ QUnit.test('should fire "tabs:change" event on global context when user click th
 	assert.deepEqual(callback.getCall(0).args[0], {
 		eventName: 'tabs:change',
 		instance: this.view,
-		active: 1
+		selected: 1
 	});
 });
 
@@ -285,11 +285,11 @@ QUnit.test('should toggle disabled state on tabs', function(assert) {
 
 QUnit.test('should not activate disabled tabs', function(assert) {
 	this.view.render();
-	this.view.active = 0;
+	this.view.selected = 0;
 	this.view.disableTabAt(1);
-	this.view.active = 1;
+	this.view.selected = 1;
 
-	assert.equal(this.view.active, 0);
+	assert.equal(this.view.selected, 0);
 });
 
 QUnit.test('should not activate disabled tabs on click', function(assert) {
@@ -305,7 +305,7 @@ QUnit.test('should not activate disabled tabs on click', function(assert) {
 
 	this.view.$el.find('li').eq(1).find('a').trigger($.Event('click'));
 
-	assert.equal(this.view.active, 0);
+	assert.equal(this.view.selected, 0);
 	assert.ok(contextCallback.notCalled);
 	assert.ok(viewCallback.notCalled);
 });
@@ -341,7 +341,7 @@ QUnit.test('should use "root" as lookup context for tab panels', function(assert
 			el: this.root.find('.tabs')[0],
 			root: root,
 			context: this.context,
-			active: -1
+			selected: -1
 		})
 	;
 
@@ -379,15 +379,15 @@ QUnit.test('should toggle multiple tabs when multiselectable is enabled', functi
 
 	// Container 1:
 	assert.equal($('#tab-a').attr('aria-hidden'), 'false', 'the first container should be not hidden');
-	assert.notOk($('#tab-a').hasClass('is-collapsed'), 'the first container is not collapesed by class name');
+	assert.notOk($('#tab-a').hasClass('is-collapsed'), 'the first container is not collapesed by classname');
 
 	// Container 2:
 	assert.equal($('#tab-b').attr('aria-hidden'), 'false', 'the second container should not be hidden');
-	assert.notOk($('#tab-b').hasClass('is-collapsed'), 'the second container is not collapesed by class name');
+	assert.notOk($('#tab-b').hasClass('is-collapsed'), 'the second container is not collapesed by classname');
 
 	// Container 3:
 	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
-	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by classname');
 });
 
 QUnit.test('should support keyboard navigation with "left" and "right" arrow-keys', function(assert) {
@@ -536,10 +536,10 @@ QUnit.test('should activate tab using "space" key', function(assert) {
 
 	buttonC.focus();
 	buttonC.trigger($.Event('keydown', {which: 32})); // 32 = space
-	assert.equal(this.view.active, 2, 'the active tab is the last');
+	assert.equal(this.view.selected, 2, 'the selected tab is the last');
 
 	buttonC.trigger($.Event('keydown', {which: 32})); // 32 = space
-	assert.equal(this.view.active, 2, 'the active tab is still the last');
+	assert.equal(this.view.selected, 2, 'the selected tab is still the last');
 });
 
 QUnit.test('should activate tab using "enter" key', function(assert) {
@@ -548,10 +548,10 @@ QUnit.test('should activate tab using "enter" key', function(assert) {
 
 	buttonC.focus();
 	buttonC.trigger($.Event('keydown', {which: 13})); // 13 = enter
-	assert.equal(this.view.active, 2, 'the active tab is the last');
+	assert.equal(this.view.selected, 2, 'the selected tab is the last');
 
 	buttonC.trigger($.Event('keydown', {which: 13})); // 13 = enter
-	assert.equal(this.view.active, 2, 'the active tab is still the last');
+	assert.equal(this.view.selected, 2, 'the selected tab is still the last');
 });
 
 QUnit.test('should toggle tab using "space" key when "toggleable" is enabled', function(assert) {
@@ -561,10 +561,10 @@ QUnit.test('should toggle tab using "space" key when "toggleable" is enabled', f
 
 	buttonC.focus();
 	buttonC.trigger($.Event('keydown', {which: 32})); // 32 = space
-	assert.equal(this.view.active, 2, 'the active tab is the last');
+	assert.equal(this.view.selected, 2, 'the selected tab is the last');
 
 	buttonC.trigger($.Event('keydown', {which: 32})); // 32 = space
-	assert.equal(this.view.active, -1, 'there is no active tab');
+	assert.equal(this.view.selected, -1, 'there is no selected tab');
 });
 
 QUnit.test('should toggle tab using "enter" key when "toggleable" is enabled', function(assert) {
@@ -574,10 +574,10 @@ QUnit.test('should toggle tab using "enter" key when "toggleable" is enabled', f
 
 	buttonC.focus();
 	buttonC.trigger($.Event('keydown', {which: 13})); // 13 = enter
-	assert.equal(this.view.active, 2, 'the active tab is the last');
+	assert.equal(this.view.selected, 2, 'the selected tab is the last');
 
 	buttonC.trigger($.Event('keydown', {which: 13})); // 13 = enter
-	assert.equal(this.view.active, -1, 'there is no active tab');
+	assert.equal(this.view.selected, -1, 'there is no selected tab');
 });
 
 QUnit.test('should toggle multiple tabs using "space" key when "multiselectable" is enabled', function(assert) {
@@ -600,7 +600,7 @@ QUnit.test('should toggle multiple tabs using "space" key when "multiselectable"
 	assert.equal(buttonA.attr('aria-expanded'), 'true', 'the first button is expanded');
 	assert.equal(buttonB.attr('aria-expanded'), 'true', 'the second button is expanded');
 	assert.equal(buttonC.attr('aria-expanded'), 'true', 'the third button is expanded');
-	assert.equal(this.view.active, 1, 'the active element is the last button triggered');
+	assert.equal(this.view.selected, 1, 'the selected element is the last button triggered');
 });
 
 QUnit.test('should toggle multiple tabs using "enter" key when "multiselectable" is enabled', function(assert) {
@@ -623,7 +623,7 @@ QUnit.test('should toggle multiple tabs using "enter" key when "multiselectable"
 	assert.equal(buttonA.attr('aria-expanded'), 'true', 'the first button is expanded');
 	assert.equal(buttonB.attr('aria-expanded'), 'true', 'the second button is expanded');
 	assert.equal(buttonC.attr('aria-expanded'), 'true', 'the third button is expanded');
-	assert.equal(this.view.active, 1, 'the active element is the last button triggered');
+	assert.equal(this.view.selected, 1, 'the selected element is the last button triggered');
 });
 
 QUnit.test('should prevent the default behaviour on mapped keyboard events', function(assert) {
@@ -666,20 +666,20 @@ QUnit.test('should prevent the default behaviour on mapped keyboard events', fun
 });
 
 QUnit.test(
-	'should not handle keydown events when altKey is active',
+	'should not handle keydown events when altKey is selected',
 	function(assert) {
 		var button = $('a[href="#tab-b"]');
 		this.view.render();
 
 		// enter
-		this.view.active = 0;
+		this.view.selected = 0;
 		button.focus().trigger($.Event('keydown', {which: 13, altKey: true}));
-		assert.equal(this.view.active, 0, 'no change of active element when using "enter" incl. pressed altKey.');
+		assert.equal(this.view.selected, 0, 'no change of selected element when using "enter" incl. pressed altKey.');
 
 		// space
-		this.view.active = 0;
+		this.view.selected = 0;
 		button.focus().trigger($.Event('keydown', {which: 32, altKey: true}));
-		assert.equal(this.view.active, 0, 'no change of active element when using "space" incl. pressed altKey.');
+		assert.equal(this.view.selected, 0, 'no change of selected element when using "space" incl. pressed altKey.');
 
 		// arrow left
 		button.focus().trigger($.Event('keydown', {which: 37, altKey: true}));
@@ -727,13 +727,13 @@ QUnit.test('should toggle selected state of buttons when they are focused/blured
 	assert.equal(buttonC.attr('aria-selected'), 'true');
 });
 
-QUnit.test('should use custom active class', function(assert) {
-	this.view.options.classActive = 'is-custom-active';
+QUnit.test('should use custom selected class', function(assert) {
+	this.view.options.classSelected = 'is-custom-selected';
 	this.view.render();
 
-	assert.ok(this.view.$el.find('> li').eq(0).hasClass('is-custom-active'), 'the first list element is active by classname');
-	assert.notOk(this.view.$el.find('> li').eq(1).hasClass('is-custom-active'), 'the secend list element is not active by classname.');
-	assert.notOk(this.view.$el.find('> li').eq(2).hasClass('is-custom-active'), 'the third list element is not active by classname.');
+	assert.ok(this.view.$el.find('> li').eq(0).hasClass('is-custom-selected'), 'the first list element is selected by classname');
+	assert.notOk(this.view.$el.find('> li').eq(1).hasClass('is-custom-selected'), 'the secend list element is not selected by classname.');
+	assert.notOk(this.view.$el.find('> li').eq(2).hasClass('is-custom-selected'), 'the third list element is not selected by classname.');
 });
 
 QUnit.test('should use custom collapsed class', function(assert) {

--- a/tests/tabs/views/tabs.js
+++ b/tests/tabs/views/tabs.js
@@ -1,0 +1,757 @@
+/* global QUnit, sinon */
+import $ from 'jquery';
+import _ from 'underscore';
+import Geppetto from 'backbone.geppetto';
+import View from 'picnic/tabs/views/Tabs';
+import Fixture from 'tests/tabs/views/fixtures/tabs.html!text';
+
+
+QUnit.module('The tabs view', {
+
+	beforeEach: function() {
+		this.root = $('#qunit-fixture');
+		this.element = $(Fixture).appendTo(this.root);
+		this.context = new Geppetto.Context();
+		this.view = new View({
+			el: this.root.find('.tabs')[0],
+			context: this.context
+		});
+	}
+
+});
+
+QUnit.test('should return itself on render() call', function(assert) {
+	assert.equal(this.view.render(), this.view);
+});
+
+QUnit.test('should render accessible elements', function(assert) {
+	this.view.render();
+
+	assert.equal(this.view.$el.attr('role'), 'tablist', 'the list element should be marked as "tablist"');
+	assert.equal(this.view.$el.attr('multiselectable'), 'false', 'the list element should be initially marked as not "multiselectable"');
+
+	// List entries
+	assert.ok(this.view.$el.find('> li').eq(0).hasClass('is-active'), 'the first list element is active by class name');
+	assert.notOk(this.view.$el.find('> li').eq(1).hasClass('is-active'), 'the secend list element is not active by class name');
+	assert.notOk(this.view.$el.find('> li').eq(2).hasClass('is-active'), 'the third list element is not active by class name');
+
+	// Button 1:
+	assert.equal(typeof $('a[href="#tab-a"]').attr('id'), 'string', 'the first button should have an id');
+	assert.equal($('a[href="#tab-a"]').attr('role'), 'tab', 'the first button should be marked as "tab"');
+	assert.equal($('a[href="#tab-a"]').attr('aria-selected'), 'false', 'the first button should be selected by "aria-selected"');
+	assert.equal($('a[href="#tab-a"]').attr('aria-expanded'), 'true', 'the first button should be expanded by "aria-expanded"');
+	assert.equal($('a[href="#tab-a"]').attr('aria-controls'), 'tab-a', 'the first button should control the div wich is referenced by the href-deeplink');
+
+	// Button 2:
+	assert.equal(typeof $('a[href="#tab-b"]').attr('id'), 'string', 'the second button should have an id');
+	assert.equal($('a[href="#tab-b"]').attr('role'), 'tab', 'the second button should be marked as "tab"');
+	assert.equal($('a[href="#tab-b"]').attr('aria-selected'), 'false', 'the second button should not be selected by "aria-selected"');
+	assert.equal($('a[href="#tab-b"]').attr('aria-expanded'), 'false', 'the second button should not be expanded by "aria-expanded"');
+	assert.equal($('a[href="#tab-b"]').attr('aria-controls'), 'tab-b', 'the second button should control the div wich is referenced by the href-deeplink');
+
+	// Button 3:
+	assert.equal(typeof $('a[href="#tab-c"]').attr('id'), 'string', 'the third button should have an id');
+	assert.equal($('a[href="#tab-c"]').attr('role'), 'tab', 'the third button should be marked as "tab"');
+	assert.equal($('a[href="#tab-c"]').attr('aria-selected'), 'false', 'the third button should not be selected by "aria-selected"');
+	assert.equal($('a[href="#tab-c"]').attr('aria-expanded'), 'false', 'the third button should not be expanded by "aria-expanded"');
+	assert.equal($('a[href="#tab-c"]').attr('aria-controls'), 'tab-c', 'the third button should control the div wich is referenced by the href-deeplink');
+
+	// Buttons:
+	assert.notEqual($('a[href="#tab-a"]').attr('id'), $('a[href="#tab-b"]').attr('id'), 'button ids are not equal');
+	assert.notEqual($('a[href="#tab-b"]').attr('id'), $('a[href="#tab-c"]').attr('id'), 'button ids are not equal');
+	assert.notEqual($('a[href="#tab-c"]').attr('id'), $('a[href="#tab-a"]').attr('id'), 'button ids are not equal');
+
+	// Container 1:
+	assert.equal($('#tab-a').attr('role'), 'tabpanel', 'the first container should be marked as "tabpanel"');
+	assert.equal($('#tab-a').attr('aria-hidden'), 'false', 'the first container should be not hidden');
+	assert.equal($('#tab-a').attr('aria-labelledby'), $('a[href="#tab-a"]').attr('id'), 'the first container should be labeled by the first button');
+	assert.notOk($('#tab-a').hasClass('is-collapsed'), 'the first container is not collapesed by class name');
+
+	// Container 2:
+	assert.equal($('#tab-b').attr('role'), 'tabpanel', 'the second container should be marked as "tabpanel"');
+	assert.equal($('#tab-b').attr('aria-hidden'), 'true', 'the second container should be hidden');
+	assert.equal($('#tab-b').attr('aria-labelledby'), $('a[href="#tab-b"]').attr('id'), 'the second container should be labeled by the second button');
+	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by class name');
+
+	// Container 3:
+	assert.equal($('#tab-c').attr('role'), 'tabpanel', 'the third container should be marked as "tabpanel"');
+	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
+	assert.equal($('#tab-c').attr('aria-labelledby'), $('a[href="#tab-c"]').attr('id'), 'the third container should be labeled by the third button');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+});
+
+QUnit.test('should return correct list entry by index', function(assert) {
+	this.view.render();
+
+	assert.equal(this.view.getTabAt(0)[0], this.view.$el.find('> li').get(0));
+	assert.equal(this.view.getTabAt(1)[0], this.view.$el.find('> li').get(1));
+	assert.equal(this.view.getTabAt(2)[0], this.view.$el.find('> li').get(2));
+	assert.equal(this.view.getTabAt(4711)[0], undefined);
+});
+
+QUnit.test('should return correct button by index', function(assert) {
+	this.view.render();
+
+	assert.equal(this.view.getButtonAt(0)[0], $('a[href="#tab-a"]')[0]);
+	assert.equal(this.view.getButtonAt(1)[0], $('a[href="#tab-b"]')[0]);
+	assert.equal(this.view.getButtonAt(2)[0], $('a[href="#tab-c"]')[0]);
+	assert.equal(this.view.getButtonAt(4711)[0], undefined);
+});
+
+QUnit.test('should toggle active state by click on button', function(assert) {
+	this.view.render();
+
+	$('a[href="#tab-b"]').trigger('click');
+
+	// Buttons:
+	assert.equal($('a[href="#tab-a"]').attr('aria-expanded'), 'false', 'the first button should not be expanded by "aria-expanded"');
+	assert.equal($('a[href="#tab-b"]').attr('aria-expanded'), 'true', 'the second button should be expanded by "aria-expanded"');
+	assert.equal($('a[href="#tab-c"]').attr('aria-expanded'), 'false', 'the third button should not be expanded by "aria-expanded"');
+
+	// Container 1:
+	assert.equal($('#tab-a').attr('aria-hidden'), 'true', 'the first container should be not hidden');
+	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by class name');
+
+	// Container 2:
+	assert.equal($('#tab-b').attr('aria-hidden'), 'false', 'the second container should not be hidden');
+	assert.notOk($('#tab-b').hasClass('is-collapsed'), 'the second container is not collapesed by class name');
+
+	// Container 3:
+	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+});
+
+QUnit.test('should toggle active state by property "active"', function(assert) {
+	this.view.render();
+	this.view.active = 2; // third button / container
+
+	// Buttons:
+	assert.equal($('a[href="#tab-a"]').attr('aria-expanded'), 'false', 'the first button should not be expanded by "aria-expanded"');
+	assert.equal($('a[href="#tab-b"]').attr('aria-expanded'), 'false', 'the second button should not be expanded by "aria-expanded"');
+	assert.equal($('a[href="#tab-c"]').attr('aria-expanded'), 'true', 'the third button should be expanded by "aria-expanded"');
+
+	// Container 1:
+	assert.equal($('#tab-a').attr('aria-hidden'), 'true', 'the first container should be hidden');
+	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by class name');
+
+	// Container 2:
+	assert.equal($('#tab-b').attr('aria-hidden'), 'true', 'the second container should be hidden');
+	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is not collapesed by class name');
+
+	// Container 3:
+	assert.equal($('#tab-c').attr('aria-hidden'), 'false', 'the third container should not be hidden');
+	assert.notOk($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+});
+
+QUnit.test('should be toggleable by option and click on button', function(assert) {
+	new View({
+		el: this.root.find('.tabs')[0],
+		context: this.context,
+		toggleable: true
+	}).render();
+
+	// a click on a previously active button...
+	$('a[href="#tab-a"]').trigger('click');
+
+	// Buttons:
+	assert.equal($('a[href="#tab-a"]').attr('aria-selected'), 'false', 'the first button should not be selected by "aria-selected"');
+	assert.equal($('a[href="#tab-b"]').attr('aria-selected'), 'false', 'the second button should be selected by "aria-selected"');
+	assert.equal($('a[href="#tab-c"]').attr('aria-selected'), 'false', 'the third button should not be selected by "aria-selected"');
+
+	// Container 1:
+	assert.equal($('#tab-a').attr('aria-hidden'), 'true', 'the first container should be not hidden');
+	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by class name');
+
+	// Container 2:
+	assert.equal($('#tab-b').attr('aria-hidden'), 'true', 'the second container should not be hidden');
+	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by class name');
+
+	// Container 3:
+	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+});
+
+QUnit.test('should be toggleable by option and click on button', function(assert) {
+	var view = new View({
+		el: this.root.find('.tabs')[0],
+		context: this.context,
+		toggleable: true
+	});
+
+	view.render();
+
+	// remove active state from all buttons and containers, by setting the
+	// active index twice...
+	view.active = view.active;
+
+	// Buttons:
+	assert.equal($('a[href="#tab-a"]').attr('aria-selected'), 'false', 'the first button should not be selected by "aria-selected"');
+	assert.equal($('a[href="#tab-b"]').attr('aria-selected'), 'false', 'the second button should be selected by "aria-selected"');
+	assert.equal($('a[href="#tab-c"]').attr('aria-selected'), 'false', 'the third button should not be selected by "aria-selected"');
+
+	// Container 1:
+	assert.equal($('#tab-a').attr('aria-hidden'), 'true', 'the first container should be not hidden');
+	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by class name');
+
+	// Container 2:
+	assert.equal($('#tab-b').attr('aria-hidden'), 'true', 'the second container should not be hidden');
+	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by class name');
+
+	// Container 3:
+	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+});
+
+QUnit.test('should be initially disabled when passing -1 for active property', function(assert) {
+	var view = new View({
+		el: this.root.find('.tabs')[0],
+		context: this.context,
+		active: -1
+	});
+
+	view.render();
+
+	// Buttons:
+	assert.equal($('a[href="#tab-a"]').attr('aria-selected'), 'false', 'the first button should not be selected by "aria-selected"');
+	assert.equal($('a[href="#tab-b"]').attr('aria-selected'), 'false', 'the second button should be selected by "aria-selected"');
+	assert.equal($('a[href="#tab-c"]').attr('aria-selected'), 'false', 'the third button should not be selected by "aria-selected"');
+
+	// Container 1:
+	assert.equal($('#tab-a').attr('aria-hidden'), 'true', 'the first container should be not hidden');
+	assert.ok($('#tab-a').hasClass('is-collapsed'), 'the first container is collapesed by class name');
+
+	// Container 2:
+	assert.equal($('#tab-b').attr('aria-hidden'), 'true', 'the second container should not be hidden');
+	assert.ok($('#tab-b').hasClass('is-collapsed'), 'the second container is collapesed by class name');
+
+	// Container 3:
+	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+});
+
+QUnit.test('should fire "change" event when user click through tabs', function(assert) {
+	var callback = sinon.spy();
+	this.view.on('change', callback);
+	this.view.render();
+
+	$('a[href="#tab-b"]').trigger('click');
+
+	assert.ok(callback.calledOnce);
+	assert.deepEqual(callback.getCall(0).args[0], {
+		instance: this.view,
+		active: 1
+	});
+});
+
+QUnit.test('should fire "tabs:change" event on global context when user click through tabs', function(assert) {
+	var callback = sinon.spy();
+	this.context.vent.on('tabs:change', callback);
+	this.view.render();
+
+	$('a[href="#tab-b"]').trigger('click');
+
+	assert.ok(callback.calledOnce);
+	assert.deepEqual(callback.getCall(0).args[0], {
+		eventName: 'tabs:change',
+		instance: this.view,
+		active: 1
+	});
+});
+
+QUnit.test('should initially has accessible disabled state on tabs', function(assert) {
+	this.view.$el.find('li').eq(1).addClass('is-disabled');
+	this.view.render();
+
+	assert.notOk(this.view.$el.find('li').eq(0).hasClass('is-disabled'));
+	assert.equal(this.view.$el.find('li').eq(0).find('a').attr('aria-disabled'), undefined);
+	assert.equal(this.view.$el.find('li').eq(0).find('a').attr('tabindex'), undefined);
+
+	assert.ok(this.view.$el.find('li').eq(1).hasClass('is-disabled'));
+	assert.equal(this.view.$el.find('li').eq(1).find('a').attr('aria-disabled'), 'true');
+	assert.equal(this.view.$el.find('li').eq(1).find('a').attr('tabindex'), '-1');
+});
+
+QUnit.test('should toggle disabled state on tabs', function(assert) {
+	this.view.render();
+
+	this.view.disableTabAt(1);
+	assert.ok(this.view.$el.find('li').eq(1).hasClass('is-disabled'));
+	assert.equal(this.view.$el.find('li').eq(1).find('a').attr('aria-disabled'), 'true');
+
+	this.view.enableTabAt(1);
+	assert.notOk(this.view.$el.find('li').eq(1).hasClass('is-disabled'));
+	assert.equal(this.view.$el.find('li').eq(1).find('a').attr('aria-disabled'), undefined);
+});
+
+QUnit.test('should not activate disabled tabs', function(assert) {
+	this.view.render();
+	this.view.active = 0;
+	this.view.disableTabAt(1);
+	this.view.active = 1;
+
+	assert.equal(this.view.active, 0);
+});
+
+QUnit.test('should not activate disabled tabs on click', function(assert) {
+	var
+		contextCallback = sinon.spy(),
+		viewCallback = sinon.spy()
+	;
+
+	this.context.vent.on('tabs:change', contextCallback);
+	this.view.on('change', viewCallback);
+	this.view.render();
+	this.view.disableTabAt(1);
+
+	this.view.$el.find('li').eq(1).find('a').trigger($.Event('click'));
+
+	assert.equal(this.view.active, 0);
+	assert.ok(contextCallback.notCalled);
+	assert.ok(viewCallback.notCalled);
+});
+
+QUnit.test('should return correct disabled state by index', function(assert) {
+	this.view.render();
+	this.view.disableTabAt(1);
+
+	assert.notOk(this.view.isDisabledTabAt(0));
+	assert.ok(this.view.isDisabledTabAt(1));
+});
+
+QUnit.test('should always retrun "false" when asking for disabled state out of index', function(assert) {
+	this.view.$el.find('li').addClass('is-disabled');
+	this.view.render();
+	assert.notOk(this.view.isDisabledTabAt(-1));
+	assert.ok(this.view.isDisabledTabAt(0));
+	assert.ok(this.view.isDisabledTabAt(1));
+	assert.ok(this.view.isDisabledTabAt(2));
+	assert.notOk(this.view.isDisabledTabAt(3));
+});
+
+QUnit.test('should use "root" as lookup context for tab panels', function(assert) {
+	var
+		template =
+			'<div>' +
+				'<div id="tab-a"><h2>Tab A</h2></div>' +
+				'<div id="tab-b"><h2>Tab B</h2></div>' +
+				'<div id="tab-c"><h2>Tab C</h2></div>' +
+			'</div>',
+		root = $(template),
+		view = new View({
+			el: this.root.find('.tabs')[0],
+			root: root,
+			context: this.context,
+			active: -1
+		})
+	;
+
+	view.render();
+
+	assert.equal(this.root.find('#tab-a').attr('role'), undefined, 'Gobal element is not marked as panel');
+	assert.equal(root.find('#tab-a').attr('role'), 'tabpanel', 'Not attached root element is marked as panel');
+});
+
+QUnit.test('should be not multiselectable by default', function(assert) {
+	this.view.render();
+
+	assert.equal(this.view.$el.attr('multiselectable'), 'false', 'the list element should be initially marked as not "multiselectable"');
+	assert.notOk(this.view.isMultiselectable, 'multiselectable is disabled');
+});
+
+QUnit.test('should enable multiselectable', function(assert) {
+	this.view.options.multiselectable = true;
+	this.view.render();
+
+	assert.equal(this.view.$el.attr('multiselectable'), 'true', 'the list element should be initially marked as "multiselectable"');
+	assert.ok(this.view.isMultiselectable, 'return true when multiselectable is enabled');
+});
+
+QUnit.test('should toggle multiple tabs when multiselectable is enabled', function(assert) {
+	this.view.options.multiselectable = true;
+	this.view.render();
+
+	$('a[href="#tab-b"]').trigger('click');
+
+	// Buttons:
+	assert.equal($('a[href="#tab-a"]').attr('aria-expanded'), 'true', 'the first button should still be expanded by "aria-expanded"');
+	assert.equal($('a[href="#tab-b"]').attr('aria-expanded'), 'true', 'the second button should be expanded by "aria-expanded"');
+	assert.equal($('a[href="#tab-c"]').attr('aria-expanded'), 'false', 'the third button should not be expanded by "aria-expanded"');
+
+	// Container 1:
+	assert.equal($('#tab-a').attr('aria-hidden'), 'false', 'the first container should be not hidden');
+	assert.notOk($('#tab-a').hasClass('is-collapsed'), 'the first container is not collapesed by class name');
+
+	// Container 2:
+	assert.equal($('#tab-b').attr('aria-hidden'), 'false', 'the second container should not be hidden');
+	assert.notOk($('#tab-b').hasClass('is-collapsed'), 'the second container is not collapesed by class name');
+
+	// Container 3:
+	assert.equal($('#tab-c').attr('aria-hidden'), 'true', 'the third container should be hidden');
+	assert.ok($('#tab-c').hasClass('is-collapsed'), 'the third container is collapesed by class name');
+});
+
+QUnit.test('should support keyboard navigation with "left" and "right" arrow-keys', function(assert) {
+	var
+		buttonA = $('a[href="#tab-a"]'),
+		buttonB = $('a[href="#tab-b"]'),
+		buttonC = $('a[href="#tab-c"]')
+	;
+
+	this.view.render();
+	buttonA.focus();
+
+	buttonA.trigger($.Event('keydown', {which: 39})); // 39 = arrow right
+	assert.equal(document.activeElement, buttonB[0], 'the focused button is the second when using arrow right');
+
+	buttonB.trigger($.Event('keydown', {which: 39})); // 39 = arrow right
+	assert.equal(document.activeElement, buttonC[0], 'the focused button is the third when using arrow right twice');
+
+	buttonC.trigger($.Event('keydown', {which: 39})); // 39 = arrow right
+	assert.equal(document.activeElement, buttonA[0], 'the focused button is the first again when using arrow right (loop)');
+
+	buttonA.trigger($.Event('keydown', {which: 37})); // 37 = arrow left
+	assert.equal(document.activeElement, buttonC[0], 'the focused button is the last when using arrow left (loop)');
+
+	buttonC.trigger($.Event('keydown', {which: 37})); // 37 = arrow left
+	assert.equal(document.activeElement, buttonB[0], 'the focused button is the second when using arrow left');
+});
+
+QUnit.test('should support keyboard navigation with "left" and "right" arrow-keys when buttons are disabled', function(assert) {
+	var
+		buttonA = $('a[href="#tab-a"]'),
+		buttonC = $('a[href="#tab-c"]')
+	;
+
+	this.view.render();
+	this.view.disableTabAt(1);
+	buttonA.focus();
+
+	buttonA.trigger($.Event('keydown', {which: 39})); // 39 = arrow right
+	assert.equal(document.activeElement, buttonC[0], 'the focused button is the last when using arrow right');
+
+	buttonC.trigger($.Event('keydown', {which: 37})); // 37 = arrow left
+	assert.equal(document.activeElement, buttonA[0], 'the focused button is the first when using arrow right');
+
+	this.view.disableTabAt(2);
+	buttonA.trigger($.Event('keydown', {which: 39})); // 39 = arrow right
+	assert.equal(document.activeElement, buttonA[0], 'the focused button is the still first when using arrow right');
+
+	buttonA.trigger($.Event('keydown', {which: 37})); // 37 = arrow left
+	assert.equal(document.activeElement, buttonA[0], 'the focused button is the still first when using arrow right');
+});
+
+QUnit.test('should support keyboard navigation with "up" and "down" arrow-keys', function(assert) {
+	var
+		buttonA = $('a[href="#tab-a"]'),
+		buttonB = $('a[href="#tab-b"]'),
+		buttonC = $('a[href="#tab-c"]')
+	;
+
+	this.view.render();
+	buttonA.focus();
+
+	buttonA.trigger($.Event('keydown', {which: 40})); // 40 = arrow down
+	assert.equal(document.activeElement, buttonB[0], 'the focused button is the second when using arrow down');
+
+	buttonB.trigger($.Event('keydown', {which: 40})); // 40 = arrow down
+	assert.equal(document.activeElement, buttonC[0], 'the focused button is the third when using arrow down twice');
+
+	buttonC.trigger($.Event('keydown', {which: 40})); // 40 = arrow down
+	assert.equal(document.activeElement, buttonA[0], 'the focused button is the first again when using arrow down (loop)');
+
+	buttonA.trigger($.Event('keydown', {which: 38})); // 38 = arrow up
+	assert.equal(document.activeElement, buttonC[0], 'the focused button is the last when using arrow up (loop)');
+
+	buttonC.trigger($.Event('keydown', {which: 38})); // 38 = arrow up
+	assert.equal(document.activeElement, buttonB[0], 'the focused button is the second when using arrow up');
+});
+
+QUnit.test('should support keyboard navigation with "up" and "down" arrow-keys when buttons are disabled', function(assert) {
+	var
+		buttonA = $('a[href="#tab-a"]'),
+		buttonC = $('a[href="#tab-c"]')
+	;
+
+	this.view.render();
+	this.view.disableTabAt(1);
+	buttonA.focus();
+
+	buttonA.trigger($.Event('keydown', {which: 40})); // 40 = arrow down
+	assert.equal(document.activeElement, buttonC[0], 'the focused button is the last when using arrow right');
+
+	buttonC.trigger($.Event('keydown', {which: 38})); // 38 = arrow up
+	assert.equal(document.activeElement, buttonA[0], 'the focused button is the first when using arrow right');
+
+	this.view.disableTabAt(2);
+	buttonA.trigger($.Event('keydown', {which: 40})); // 40 = arrow down
+	assert.equal(document.activeElement, buttonA[0], 'the focused button is the still first when using arrow right');
+
+	buttonA.trigger($.Event('keydown', {which: 38})); // 38 = arrow up
+	assert.equal(document.activeElement, buttonA[0], 'the focused button is the still first when using arrow right');
+});
+
+QUnit.test('should support keyboard navigation with "end" and "home" keys', function(assert) {
+	var
+		buttonA = $('a[href="#tab-a"]'),
+		buttonC = $('a[href="#tab-c"]')
+	;
+
+	this.view.render();
+	buttonA.focus();
+
+	buttonA.trigger($.Event('keydown', {which: 35})); // 35 = end
+	assert.equal(document.activeElement, buttonC[0], 'the focused button is the last when using end key');
+
+	buttonC.trigger($.Event('keydown', {which: 35})); // 35 = end
+	assert.equal(document.activeElement, buttonC[0], 'the focused button is still the last when using end key twice');
+
+	buttonC.trigger($.Event('keydown', {which: 36})); // 36 = home
+	assert.equal(document.activeElement, buttonA[0], 'the focused button is the first when using home key');
+
+	buttonA.trigger($.Event('keydown', {which: 36})); // 36 = home
+	assert.equal(document.activeElement, buttonA[0], 'the focused button is the still the first when using home key twice');
+});
+
+QUnit.test('should support keyboard navigation with "end" and "home" arrow-keys when buttons are disabled', function(assert) {
+	var
+		buttonA = $('a[href="#tab-a"]'),
+		buttonB = $('a[href="#tab-b"]')
+	;
+
+	this.view.render();
+	this.view.disableTabAt(2);
+	buttonA.focus();
+
+	buttonA.trigger($.Event('keydown', {which: 35})); // 35 = end
+	assert.equal(document.activeElement, buttonB[0], 'the focused button is the middle when using end');
+
+	this.view.disableTabAt(0);
+	buttonB.trigger($.Event('keydown', {which: 36})); // 36 = home
+	assert.equal(document.activeElement, buttonB[0], 'the focused button is still the middle when using home');
+});
+
+QUnit.test('should activate tab using "space" key', function(assert) {
+	var buttonC = $('a[href="#tab-c"]');
+	this.view.render();
+
+	buttonC.focus();
+	buttonC.trigger($.Event('keydown', {which: 32})); // 32 = space
+	assert.equal(this.view.active, 2, 'the active tab is the last');
+
+	buttonC.trigger($.Event('keydown', {which: 32})); // 32 = space
+	assert.equal(this.view.active, 2, 'the active tab is still the last');
+});
+
+QUnit.test('should activate tab using "enter" key', function(assert) {
+	var buttonC = $('a[href="#tab-c"]');
+	this.view.render();
+
+	buttonC.focus();
+	buttonC.trigger($.Event('keydown', {which: 13})); // 13 = enter
+	assert.equal(this.view.active, 2, 'the active tab is the last');
+
+	buttonC.trigger($.Event('keydown', {which: 13})); // 13 = enter
+	assert.equal(this.view.active, 2, 'the active tab is still the last');
+});
+
+QUnit.test('should toggle tab using "space" key when "toggleable" is enabled', function(assert) {
+	var buttonC = $('a[href="#tab-c"]');
+	this.view.options.toggleable = true;
+	this.view.render();
+
+	buttonC.focus();
+	buttonC.trigger($.Event('keydown', {which: 32})); // 32 = space
+	assert.equal(this.view.active, 2, 'the active tab is the last');
+
+	buttonC.trigger($.Event('keydown', {which: 32})); // 32 = space
+	assert.equal(this.view.active, -1, 'there is no active tab');
+});
+
+QUnit.test('should toggle tab using "enter" key when "toggleable" is enabled', function(assert) {
+	var buttonC = $('a[href="#tab-c"]');
+	this.view.options.toggleable = true;
+	this.view.render();
+
+	buttonC.focus();
+	buttonC.trigger($.Event('keydown', {which: 13})); // 13 = enter
+	assert.equal(this.view.active, 2, 'the active tab is the last');
+
+	buttonC.trigger($.Event('keydown', {which: 13})); // 13 = enter
+	assert.equal(this.view.active, -1, 'there is no active tab');
+});
+
+QUnit.test('should toggle multiple tabs using "space" key when "multiselectable" is enabled', function(assert) {
+	var
+		buttonA = $('a[href="#tab-a"]'),
+		buttonB = $('a[href="#tab-b"]'),
+		buttonC = $('a[href="#tab-c"]')
+	;
+	this.view.options.multiselectable = true;
+	this.view.render();
+
+	// Didn't need to focus the first button, it is open by default...
+
+	buttonC.focus();
+	buttonC.trigger($.Event('keydown', {which: 32})); // 32 = space
+
+	buttonB.focus();
+	buttonB.trigger($.Event('keydown', {which: 32})); // 32 = space
+
+	assert.equal(buttonA.attr('aria-expanded'), 'true', 'the first button is expanded');
+	assert.equal(buttonB.attr('aria-expanded'), 'true', 'the second button is expanded');
+	assert.equal(buttonC.attr('aria-expanded'), 'true', 'the third button is expanded');
+	assert.equal(this.view.active, 1, 'the active element is the last button triggered');
+});
+
+QUnit.test('should toggle multiple tabs using "enter" key when "multiselectable" is enabled', function(assert) {
+	var
+		buttonA = $('a[href="#tab-a"]'),
+		buttonB = $('a[href="#tab-b"]'),
+		buttonC = $('a[href="#tab-c"]')
+	;
+	this.view.options.multiselectable = true;
+	this.view.render();
+
+	// Didn't need to focus the first button, it is open by default...
+
+	buttonC.focus();
+	buttonC.trigger($.Event('keydown', {which: 13})); // 13 = enter
+
+	buttonB.focus();
+	buttonB.trigger($.Event('keydown', {which: 13})); // 13 = enter
+
+	assert.equal(buttonA.attr('aria-expanded'), 'true', 'the first button is expanded');
+	assert.equal(buttonB.attr('aria-expanded'), 'true', 'the second button is expanded');
+	assert.equal(buttonC.attr('aria-expanded'), 'true', 'the third button is expanded');
+	assert.equal(this.view.active, 1, 'the active element is the last button triggered');
+});
+
+QUnit.test('should prevent the default behaviour on mapped keyboard events', function(assert) {
+	var
+		callback = sinon.spy(),
+		button = $('a[href="#tab-a"]'),
+		tests = [
+			{which: 13, isDefaultPrevented: true}, // enter
+			{which: 32, isDefaultPrevented: true}, // space
+			{which: 37, isDefaultPrevented: true}, // arrow left
+			{which: 38, isDefaultPrevented: true}, // arrow up
+			{which: 39, isDefaultPrevented: true}, // arrow right
+			{which: 40, isDefaultPrevented: true}, // arrow down
+			{which: 35, isDefaultPrevented: true}, // end
+			{which: 36, isDefaultPrevented: true}, // home
+			{which: 9, isDefaultPrevented: false}, // tab
+			{which: 33, isDefaultPrevented: false}, // page up
+			{which: 34, isDefaultPrevented: false}, // page down
+			{which: 27, isDefaultPrevented: false} // esc
+		],
+		event
+	;
+
+	this.view.render();
+	this.view.$el.on('keydown', callback);
+
+	_.each(tests, (test, index) => {
+		button.focus();
+		button.trigger($.Event('keydown', {which: test.which}));
+
+		event = callback.getCall(index).args[0];
+		assert.equal(
+			event.isDefaultPrevented(),
+			test.isDefaultPrevented,
+			'the key "' + test.which + '" is' +
+			(test.isDefaultPrevented ? '' : ' not') +
+			' default prevented'
+		);
+	});
+});
+
+QUnit.test(
+	'should not handle keydown events when altKey is active',
+	function(assert) {
+		var button = $('a[href="#tab-b"]');
+		this.view.render();
+
+		// enter
+		this.view.active = 0;
+		button.focus().trigger($.Event('keydown', {which: 13, altKey: true}));
+		assert.equal(this.view.active, 0, 'no change of active element when using "enter" incl. pressed altKey.');
+
+		// space
+		this.view.active = 0;
+		button.focus().trigger($.Event('keydown', {which: 32, altKey: true}));
+		assert.equal(this.view.active, 0, 'no change of active element when using "space" incl. pressed altKey.');
+
+		// arrow left
+		button.focus().trigger($.Event('keydown', {which: 37, altKey: true}));
+		assert.equal(document.activeElement, button[0], 'no change of focued element when using "arrow left" incl. pressed altKey.');
+
+		// arrow up
+		button.focus().trigger($.Event('keydown', {which: 38, altKey: true}));
+		assert.equal(document.activeElement, button[0], 'no change of focued element when using "arrow up" incl. pressed altKey.');
+
+		// arrow right
+		button.focus().trigger($.Event('keydown', {which: 39, altKey: true}));
+		assert.equal(document.activeElement, button[0], 'no change of focued element when using "arrow right" incl. pressed altKey.');
+
+		// arrow down
+		button.focus().trigger($.Event('keydown', {which: 40, altKey: true}));
+		assert.equal(document.activeElement, button[0], 'no change of focued element when using "arrow down" incl. pressed altKey.');
+
+		// end
+		button.focus().trigger($.Event('keydown', {which: 35, altKey: true}));
+		assert.equal(document.activeElement, button[0], 'no change of focued element when using "end" incl. pressed altKey.');
+
+		// home
+		button.focus().trigger($.Event('keydown', {which: 36, altKey: true}));
+		assert.equal(document.activeElement, button[0], 'no change of focued element when using "home" incl. pressed altKey.');
+	}
+);
+
+QUnit.test('should toggle selected state of buttons when they are focused/blured', function(assert) {
+	var
+		buttonA = $('a[href="#tab-a"]'),
+		buttonB = $('a[href="#tab-b"]'),
+		buttonC = $('a[href="#tab-c"]')
+	;
+
+	this.view.render();
+
+	buttonA.focus();
+	assert.equal(buttonA.attr('aria-selected'), 'true');
+	assert.equal(buttonB.attr('aria-selected'), 'false');
+	assert.equal(buttonC.attr('aria-selected'), 'false');
+
+	buttonC.focus();
+	assert.equal(buttonA.attr('aria-selected'), 'false');
+	assert.equal(buttonB.attr('aria-selected'), 'false');
+	assert.equal(buttonC.attr('aria-selected'), 'true');
+});
+
+QUnit.test('should use custom active class', function(assert) {
+	this.view.options.classActive = 'is-custom-active';
+	this.view.render();
+
+	assert.ok(this.view.$el.find('> li').eq(0).hasClass('is-custom-active'), 'the first list element is active by classname');
+	assert.notOk(this.view.$el.find('> li').eq(1).hasClass('is-custom-active'), 'the secend list element is not active by classname.');
+	assert.notOk(this.view.$el.find('> li').eq(2).hasClass('is-custom-active'), 'the third list element is not active by classname.');
+});
+
+QUnit.test('should use custom collapsed class', function(assert) {
+	this.view.options.classCollapsed = 'is-custom-collapsed';
+	this.view.render();
+
+	assert.notOk(this.root.find('#tab-a').hasClass('is-custom-collapsed'), 'the first panel is not collapsed by classname.');
+	assert.ok(this.root.find('#tab-b').hasClass('is-custom-collapsed'), 'the secend panel is collapsed by classname.');
+	assert.ok(this.root.find('#tab-c').hasClass('is-custom-collapsed'), 'the third panel is collapsed by classname.');
+});
+
+QUnit.test('should use custom disabled class', function(assert) {
+	this.view.options.classDisabled = 'is-custom-disabled';
+	this.view.$el.find('li').eq(0).addClass('is-custom-disabled');
+	this.view.render();
+
+	assert.ok(this.view.isDisabledTabAt(0), 'uses custom classname on initialization.');
+
+	this.view.disableTabAt(1);
+	assert.ok(this.view.isDisabledTabAt(1), 'sets custom classname dynamicly.');
+});

--- a/tests/tabs/views/tabs.js
+++ b/tests/tabs/views/tabs.js
@@ -28,7 +28,7 @@ QUnit.test('should render accessible elements', function(assert) {
 	this.view.render();
 
 	assert.equal(this.view.$el.attr('role'), 'tablist', 'the list element should be marked as "tablist"');
-	assert.equal(this.view.$el.attr('multiselectable'), 'false', 'the list element should be initially marked as not "multiselectable"');
+	assert.equal(this.view.$el.attr('aria-multiselectable'), 'false', 'the list element should be initially marked as not "multiselectable"');
 
 	// List entries
 	assert.ok(this.view.$el.find('> li').eq(0).hasClass('is-selected'), 'the first list element is selected by classname');
@@ -354,7 +354,7 @@ QUnit.test('should use "root" as lookup context for tab panels', function(assert
 QUnit.test('should be not multiselectable by default', function(assert) {
 	this.view.render();
 
-	assert.equal(this.view.$el.attr('multiselectable'), 'false', 'the list element should be initially marked as not "multiselectable"');
+	assert.equal(this.view.$el.attr('aria-multiselectable'), 'false', 'the list element should be initially marked as not "multiselectable"');
 	assert.notOk(this.view.isMultiselectable, 'multiselectable is disabled');
 });
 
@@ -362,7 +362,7 @@ QUnit.test('should enable multiselectable', function(assert) {
 	this.view.options.multiselectable = true;
 	this.view.render();
 
-	assert.equal(this.view.$el.attr('multiselectable'), 'true', 'the list element should be initially marked as "multiselectable"');
+	assert.equal(this.view.$el.attr('aria-multiselectable'), 'true', 'the list element should be initially marked as "multiselectable"');
 	assert.ok(this.view.isMultiselectable, 'return true when multiselectable is enabled');
 });
 

--- a/tests/tabs/views/tabs.js
+++ b/tests/tabs/views/tabs.js
@@ -24,6 +24,20 @@ QUnit.test('should return itself on render() call', function(assert) {
 	assert.equal(this.view.render(), this.view);
 });
 
+QUnit.test('should have expected defaults', function(assert) {
+	assert.deepEqual(this.view.options, {
+		el: this.root.find('.tabs')[0],
+		context: this.context,
+		root: null,
+		selected: [0],
+		toggleable: false,
+		multiselectable: false,
+		classSelected: 'is-selected',
+		classCollapsed: 'is-collapsed',
+		classDisabled: 'is-disabled'
+	});
+});
+
 QUnit.test('should render accessible elements', function(assert) {
 	this.view.render();
 


### PR DESCRIPTION
I've added a new module according to #38, which allows us to simply create a tablist navigation by using simple markup like:

```html
<ul class="tabs">
	<li><a href="#tab1" title="Open tab 1">Tab 1</a></li>
	<li><a href="#tab2" title="Open tab 2">Tab 2</a></li>
	<li class="is-disabled"><a href="#tab3" title="Open tab 3">Tab 3 (disabled)</a></li>
</ul>

<div id="#tab1"><h2>Tab 1 content</h2></div>
<div id="#tab2"><h2>Tab 2 content</h2></div>
<div id="#tab3"><h2>Tab 3 content</h2></div>
```

It enables accessible support using WAI-ARIA attributes (https://www.w3.org/TR/wai-aria-1.1/) and keyboard inputs (arrowbuttons, space, enter, end, home).

As a result of an accordion is technically an tablist navigation, this module also supports accordions by changing the markup:

```html
<div class="accordion">
	<h2><a href="#section1" title="Open section 1">Section 1</a></h2>
	<div id="section1"><p>Section 1</p></div>
	
	<h2><a href="#section2" title="Open section 2">Section 2</a></h2>
	<div id="section2"><p>Section 2</p></div>
	
	<h2><a href="#section3" title="Open section 3">Section 3</a></h2>
	<div id="section3"><p>Section 3</p></div>
</div>
```

It's inspired by: http://www.oaa-accessibility.org/examplep/accordian1/

See the prepared documentation of the module: https://github.com/moccu/picnic/tree/feature/tabs#tabs